### PR TITLE
docs(userspace): first-boot con sibling y make run sin toolchain

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -23,7 +23,8 @@ The goal is to document implemented behavior first, then known gaps.
 - `STABLE.md`: release 0.0.1 checklist; merge→`master` blockers = TinyCC + Doom T2.
 - `BACKLOG_REMAINING.md`: honest post-0.0.1 open work (storage, POSIX, residual).
 - `KTM.md`: **canonical KTM guide** — internals, **klog layers**, kernel API, `/dev/ktm`, gates (Spanish: `esp/KTM.md`).
-- `USERSPACE.md`: **kernel ↔ IR0-userspace coupling** — clone layout, `IR0_USERSPACE_ROOT`, `headers_install`, boundary rules (Spanish: `esp/USERSPACE.md`).
+- `USERSPACE.md`: **kernel ↔ IR0-userspace coupling** — `make first-boot`, BusyBox
+  path, no-init panic contract (Spanish: `esp/USERSPACE.md`).
 - `KLOG.md`: **structured event core** — `klog_record`, phases, early clock, sinks, `/proc/kmsg`, product boot via runit/ash (Spanish: `esp/KLOG.md`).
 - `KTM_FASE_PARITY.md`: FASE oleada → KTM analogue map (COVERED/PARTIAL/GAP/SUB).
 - `KTM_FASE_INVENTORY.md`: legacy `smoke-fase*` class A/B/C and canonical KTM gates.

--- a/Documentation/USERSPACE.md
+++ b/Documentation/USERSPACE.md
@@ -1,20 +1,60 @@
 # Coupling IR0 (kernel) ↔ IR0-userspace
 
-> **Last verified:** 2026-07-25  
-> **Source of truth:** this file, `Makefile` (`IR0_USERSPACE_ROOT`, `check-userspace`, `headers_install`), sibling [IR0-userspace](https://github.com/IRodriguez13/IR0-userspace), [SETUP.md](../SETUP.md) (sibling section), and [TREE_CONTRACT](../../IR0-desktop/Documentation/TREE_CONTRACT.md) when present.  
+> **Last verified:** 2026-07-26  
+> **Source of truth:** this file, `Makefile` (`IR0_USERSPACE_ROOT`, `check-userspace`, `headers_install`, `bootstrap-userspace`), sibling [IR0-userspace](https://github.com/IRodriguez13/IR0-userspace), [SETUP.md](../SETUP.md).  
 > **Spanish:** [`esp/USERSPACE.md`](esp/USERSPACE.md)
 
-## Boundary
+## Why two repositories?
+
+The kernel alone is not a Unix distro. Product PID1 (**runit**), **BusyBox**, login/doas, and `/etc` live in **IR0-userspace**. Boot always does `kexecve("/sbin/init")` from `disk.img`.
 
 | Lives in **IR0** | Lives in **IR0-userspace** |
 |------------------|----------------------------|
 | Kernel, drivers, UAPI (`includes/uapi/`) | runit, BusyBox, login/doas, product `/etc` |
 | Kernel test fixtures (`setup/pid1/`) | Package recipes, services, rootfs profiles |
-| Orchestration Make targets that *delegate* | Built ELFs and `disk.img` under `out/` |
+| Orchestration Make targets that *delegate* | Built ELFs under `out/` |
 
 **Hard rule:** if PID 1 can replace it without recompiling the kernel, it does not live in IR0.
 
-Product boot always `kexecve("/sbin/init")`. There is no in-kernel debug shell or `debug_bins/` ring-0 command harness.
+## Fastest path (first time)
+
+From an empty parent directory:
+
+```bash
+git clone https://github.com/IRodriguez13/IR0.git
+cd IR0
+make check-env
+make defconfig
+
+# Clones ../IR0-userspace if missing, exports UAPI, builds runit+BusyBox → disk.img + ISO
+make first-boot
+
+# Boot the minimal distro (getty → BusyBox ash)
+make run
+```
+
+Equivalent one-liner from the kernel tree after `defconfig`:
+
+```bash
+./scripts/bootstrap-userspace.sh && make run
+```
+
+Inside the guest (development profile often autologins as root):
+
+```text
+busybox
+ls /
+cat /proc/version
+echo hello
+```
+
+| Target | Role |
+|--------|------|
+| `make first-boot` / `bootstrap-userspace` | Clone sibling + minimal rootfs + ISO |
+| `make run` | QEMU GTK — runit + BusyBox (no TinyCC required) |
+| `make run-console` | Same disk, serial only |
+| `IR0_WITH_DEVTOOLS=1 make run` | Also inject TinyCC + GNU make (optional) |
+| `make smoke-runit-boot` | Non-interactive boot gate |
 
 ## Suggested layout
 
@@ -22,48 +62,44 @@ Product boot always `kexecve("/sbin/init")`. There is no in-kernel debug shell o
 parent/
 ├── IR0/                 # this tree
 ├── IR0-userspace/       # https://github.com/IRodriguez13/IR0-userspace
-└── IR0-desktop/         # optional desktop product + DESK smokes
+└── IR0-desktop/         # optional
 ```
 
-Override paths if needed:
-
 ```bash
-export IR0_USERSPACE_ROOT=/path/to/IR0-userspace
-export IR0_ROOT=/path/to/IR0          # from the userspace tree
-```
-
-## Wire-up (kernel side)
-
-```bash
-# 1. Clone sibling next to IR0 (or set IR0_USERSPACE_ROOT)
-git clone https://github.com/IRodriguez13/IR0-userspace.git ../IR0-userspace
-
-# 2. Export public ABI for userspace builds
-make headers_install DESTDIR=../IR0-userspace/out/sysroot
-
-# 3. Build / install product rootfs (delegates to sibling)
-make check-userspace
-make build-runit
-make load-userspace-runit
-
-# 4. Boot product path
-make kernel-x64-userspace.iso
-# or: make run-pid1 / smoke-runit-boot
+export IR0_USERSPACE_ROOT=/path/to/IR0-userspace   # if not ../IR0-userspace
+export IR0_ROOT=/path/to/IR0                         # from the userspace tree
 ```
 
 `make check-userspace` **fails** if the sibling is missing (never silent skip-as-PASS).
 
-## Wire-up (userspace side)
+## Manual wire-up (same steps as the script)
+
+```bash
+git clone https://github.com/IRodriguez13/IR0-userspace.git ../IR0-userspace
+make headers_install DESTDIR=../IR0-userspace/out/sysroot
+make check-userspace
+make load-userspace-runit          # builds BusyBox/runit via sibling + injects disk.img
+make kernel-x64-userspace.iso
+make run
+```
 
 From `IR0-userspace`:
 
 ```bash
 export IR0_ROOT=../IR0
 make fetch build rootfs
-# optional: make image   # needs a built kernel ISO from IR0_ROOT
 ```
 
-See `IR0-userspace/README.md` and `userspace/README.md` in this tree (pointer only).
+## Boot contract: no init / init dies
+
+| Situation | Kernel behavior |
+|-----------|-----------------|
+| `disk.img` missing `/sbin/init` or `kexecve` fails | **`panic("Failed to load /sbin/init")`** — there is no in-kernel shell |
+| Init loads and scheduler runs | Normal product path (runit → getty → ash) |
+| Init **exits** | Children reparented; kernel **idle** loop keeps the CPU alive — not a second panic by default. Userspace is effectively dead (no getty). |
+| Init never present because sibling not loaded | Same as first row: panic at handoff |
+
+There is **no** dbgshell fallback. Always inject a product rootfs (`make first-boot` / `load-userspace-runit`) before expecting a shell.
 
 ## What this tree must not re-add
 

--- a/Documentation/esp/USERSPACE.md
+++ b/Documentation/esp/USERSPACE.md
@@ -1,61 +1,54 @@
 # Acoplamiento IR0 (kernel) ↔ IR0-userspace
 
-> **Última verificación:** 2026-07-25  
-> **Fuente de verdad:** este archivo, `Makefile` (`IR0_USERSPACE_ROOT`, `check-userspace`, `headers_install`), hermano [IR0-userspace](https://github.com/IRodriguez13/IR0-userspace), y [TREE_CONTRACT](../../../IR0-desktop/Documentation/TREE_CONTRACT.md) si existe.  
+> **Última verificación:** 2026-07-26  
+> **Fuente de verdad:** este archivo, `Makefile` (`bootstrap-userspace`, `IR0_USERSPACE_ROOT`), hermano [IR0-userspace](https://github.com/IRodriguez13/IR0-userspace), [SETUP.md](../../SETUP.md).  
 > **Inglés:** [`../USERSPACE.md`](../USERSPACE.md)
 
-## Límite
+## ¿Por qué dos repos?
 
-| Vive en **IR0** | Vive en **IR0-userspace** |
-|-----------------|---------------------------|
-| Kernel, drivers, UAPI (`includes/uapi/`) | runit, BusyBox, login/doas, `/etc` de producto |
-| Fixtures de test (`setup/pid1/`) | Recetas de paquetes, servicios, perfiles rootfs |
-| Targets Make que *delegan* | ELFs y `disk.img` bajo `out/` |
+El kernel solo no es una distro Unix. El PID1 de producto (**runit**), **BusyBox**, login/doas y `/etc` viven en **IR0-userspace**. El boot siempre hace `kexecve("/sbin/init")` desde `disk.img`.
 
-**Regla dura:** si PID 1 puede reemplazarlo sin recompilar el kernel, no vive en IR0.
+## Camino más corto (primera vez)
 
-El boot de producto siempre hace `kexecve("/sbin/init")`. No hay shell de depuración in-kernel ni harness `debug_bins/`.
+```bash
+git clone https://github.com/IRodriguez13/IR0.git
+cd IR0
+make check-env
+make defconfig
+make first-boot    # clona ../IR0-userspace si falta + rootfs mínimo + ISO
+make run           # QEMU → getty → BusyBox ash
+```
 
-## Layout sugerido
+En el guest:
+
+```text
+busybox
+ls /
+cat /proc/version
+```
+
+| Target | Rol |
+|--------|-----|
+| `make first-boot` | Hermano + distro mínima |
+| `make run` | GTK con runit+BusyBox (sin TinyCC obligatorio) |
+| `IR0_WITH_DEVTOOLS=1 make run` | + toolchain in-guest (opcional) |
+
+## Contrato de boot: sin init / init muere
+
+| Situación | Comportamiento |
+|-----------|----------------|
+| No hay `/sbin/init` o falla `kexecve` | **`panic("Failed to load /sbin/init")`** — no hay shell in-kernel |
+| Init corre | Camino normal (runit → getty → ash) |
+| Init **sale** | Reparent; el idle del kernel sigue — no hay panic automático; el userspace queda muerto |
+| No se inyectó el rootfs del hermano | Mismo panic de la primera fila |
+
+## Layout
 
 ```text
 parent/
-├── IR0/                 # este árbol
-├── IR0-userspace/       # https://github.com/IRodriguez13/IR0-userspace
-└── IR0-desktop/         # producto desktop opcional + smokes DESK
+├── IR0/
+├── IR0-userspace/
+└── IR0-desktop/     # opcional
 ```
 
-```bash
-export IR0_USERSPACE_ROOT=/ruta/a/IR0-userspace
-export IR0_ROOT=/ruta/a/IR0          # desde el árbol userspace
-```
-
-## Cableado (lado kernel)
-
-```bash
-git clone https://github.com/IRodriguez13/IR0-userspace.git ../IR0-userspace
-make headers_install DESTDIR=../IR0-userspace/out/sysroot
-make check-userspace
-make build-runit
-make load-userspace-runit
-make kernel-x64-userspace.iso
-```
-
-`make check-userspace` **falla** si falta el hermano (nunca skip silencioso como PASS).
-
-## Cableado (lado userspace)
-
-Desde `IR0-userspace`:
-
-```bash
-export IR0_ROOT=../IR0
-make fetch build rootfs
-```
-
-Ver `IR0-userspace/README.md` y `userspace/README.md` en este árbol (solo puntero).
-
-## Qué no reintroducir en este árbol
-
-- Fuentes BusyBox / runit / doas o `/etc` de producto bajo `setup/`
-- Shell mono in-kernel (`dbgshell`) o registro `debug_bins/`
-- `#include` de userspace de producto en el link del kernel
+Docs completas en inglés: [`../USERSPACE.md`](../USERSPACE.md).

--- a/Documentation/mandocs/en/onboarding.md
+++ b/Documentation/mandocs/en/onboarding.md
@@ -32,12 +32,15 @@ Linux ABI. Subsystem depth lives in other `IR0-*` pages.
 ## 3. Data flow — first boot
 
 ```text
-  git clone → cd IR0
+  git clone IR0 → cd IR0
        → make check-env
        → make defconfig
-       → make ir0          # kernel-x64.iso
-       → make run          # QEMU (Supported path)
+       → make first-boot   # clone ../IR0-userspace + runit/BusyBox disk + ISO
+       → make run          # QEMU → getty → BusyBox ash
 ```
+
+`make ir0` builds a kernel-only ISO. Product shell needs the sibling rootfs;
+without `/sbin/init` the kernel panics at handoff. See `Documentation/USERSPACE.md`.
 
 Optional boot log on the **host** (not required for first run):
 

--- a/Documentation/mandocs/esp/onboarding.md
+++ b/Documentation/mandocs/esp/onboarding.md
@@ -23,7 +23,7 @@ Linux completa. La profundidad de subsistemas está en otras páginas `IR0-*`.
 | Pieza | Rol |
 |-------|-----|
 | `make check-env` / `deptest` | Diagnóstico host (required / optional / unusable) |
-| `make defconfig` / `ir0` / `run` | Primer boot oficial (x86-64 QEMU) |
+| `make defconfig` / `first-boot` / `run` | Primer boot oficial (x86-64 + BusyBox) |
 | `make help-profiles` | Perfiles + techos honestos |
 | `make sync-mandocs` / `make man TOPIC=` | Docs sin pelear MANPATH |
 | `make pre-submit` | Gate local → `PRE_SUBMIT_OK` |
@@ -32,12 +32,15 @@ Linux completa. La profundidad de subsistemas está en otras páginas `IR0-*`.
 ## 3. Flujo de datos — primer boot
 
 ```text
-  git clone → cd IR0
+  git clone IR0 → cd IR0
        → make check-env
        → make defconfig
-       → make ir0          # kernel-x64.iso
-       → make run          # QEMU (camino Supported)
+       → make first-boot   # clona ../IR0-userspace + rootfs BusyBox + ISO
+       → make run          # QEMU → getty → BusyBox ash
 ```
+
+Sin `/sbin/init` en `disk.img` el kernel hace panic en el handoff (no hay shell in-kernel).
+Ver `Documentation/esp/USERSPACE.md`.
 
 Boot log opcional en el **host**:
 
@@ -75,7 +78,7 @@ Boot log opcional en el **host**:
 ```text
   Nuevo contribuidor
        │
-       ├─► check-env ──► defconfig ──► ir0 ──► run
+       ├─► check-env ──► defconfig ──► first-boot ──► run
        │                                      │
        │                                      └─► (opcional) run-bootlog
        │                                                └─► host ir0-boot.log

--- a/Makefile
+++ b/Makefile
@@ -118,9 +118,20 @@ IR0_USERSPACE_MAKE = $(MAKE) -s -C $(IR0_USERSPACE_ROOT) IR0_ROOT=$(KERNEL_ROOT)
 check-userspace:
 	@if [ ! -f "$(IR0_USERSPACE_ROOT)/Makefile" ]; then \
 		echo "✗ IR0-userspace not found at $(IR0_USERSPACE_ROOT)"; \
-		echo "  clone it next to this tree or set IR0_USERSPACE_ROOT=/path/to/IR0-userspace"; \
+		echo "  First time:  make bootstrap-userspace"; \
+		echo "  Or clone:    git clone https://github.com/IRodriguez13/IR0-userspace.git ../IR0-userspace"; \
+		echo "  Or set:      IR0_USERSPACE_ROOT=/path/to/IR0-userspace"; \
 		exit 1; \
 	fi
+
+# Clone sibling (if missing), headers_install, runit+BusyBox → disk.img + ISO.
+bootstrap-userspace:
+	@chmod +x scripts/bootstrap-userspace.sh
+	@./scripts/bootstrap-userspace.sh
+
+# Alias for new contributors: same as bootstrap-userspace.
+first-boot: bootstrap-userspace
+	@echo "✓ first-boot OK — next: make run"
 
 all: $(DEFAULT_BUILD_TARGET)
 
@@ -1182,19 +1193,33 @@ windows-clean win-clean:
 # Run with GUI and disk (default) - ALL IR0 SUPPORTED HARDWARE
 # Note: This target does NOT call clean-net or rebuild with special flags
 # It simply runs the existing kernel ISO. Use 'make run-tap' for TAP networking.
-# Human console: development disk includes tcc/make + BusyBox filters.
+# Human console: minimal distro = runit + BusyBox (sibling IR0-userspace).
+# Optional in-guest TinyCC/GNU make: IR0_WITH_DEVTOOLS=1 make run
 # Ungrab mouse/keyboard in QEMU GTK: Ctrl+Alt+G (document in SETUP.md).
-run: kernel-x64-userspace.iso load-userspace-devtools
+#
+# First time (no sibling yet): make first-boot && make run
+run: kernel-x64-userspace.iso
+	@if [ "$${IR0_WITH_DEVTOOLS:-0}" = "1" ]; then \
+		$(MAKE) -s load-userspace-devtools; \
+	else \
+		$(MAKE) -s load-userspace-runit; \
+	fi
 	@echo "Running IR0/Unix (human console — clean GTK)..."
 	@echo "   Hardware: RTL8139, SB16, Adlib, ATA/IDE, Serial, PS/2, VGA"
 	@echo "   Ungrab input: Ctrl+Alt+G"
+	@echo "   Distro: runit + BusyBox (devtools: IR0_WITH_DEVTOOLS=1)"
 	qemu-system-x86_64 -cdrom kernel-x64-userspace.iso \
 		$(QEMU_HW_IR0_ALL) \
 		-m 512M -no-reboot \
 		$(QEMU_DISPLAY)
 
 # Run with GUI and serial debug output - ALL IR0 SUPPORTED HARDWARE
-run-debug: kernel-x64-userspace.iso load-userspace-devtools
+run-debug: kernel-x64-userspace.iso
+	@if [ "$${IR0_WITH_DEVTOOLS:-0}" = "1" ]; then \
+		$(MAKE) -s load-userspace-devtools; \
+	else \
+		$(MAKE) -s load-userspace-runit; \
+	fi
 	@echo "Running IR0/Unix userspace with debug output..."
 	@echo "   Hardware: RTL8139, SB16, ATA/IDE, Serial, PS/2, VGA"
 	@echo "Serial output will appear in this terminal"
@@ -1212,7 +1237,12 @@ run-debug: kernel-x64-userspace.iso load-userspace-devtools
 # run-bootlog: defined in scripts/make/hostshare-boot.mk (serial + optional 9p boot log).
 # Human interactive with serial in-terminal: make run-debug.
 
-run-fullscreen: kernel-x64-userspace.iso load-userspace-devtools
+run-fullscreen: kernel-x64-userspace.iso
+	@if [ "$${IR0_WITH_DEVTOOLS:-0}" = "1" ]; then \
+		$(MAKE) -s load-userspace-devtools; \
+	else \
+		$(MAKE) -s load-userspace-runit; \
+	fi
 	@echo "Running IR0/Unix fullscreen GTK..."
 	@echo "   Ungrab input: Ctrl+Alt+G"
 	qemu-system-x86_64 -cdrom kernel-x64-userspace.iso \

--- a/README.md
+++ b/README.md
@@ -12,17 +12,27 @@ where unimplemented).
 
 Complexity belongs in the code — starting should not.
 
+Product userspace (runit + BusyBox) lives in a **sibling repo**. First boot:
+
 ```bash
 git clone https://github.com/IRodriguez13/IR0.git
 cd IR0
-make check-env            # alias: make deptest — actionable host diagnostic
+make check-env            # host diagnostic
 make defconfig
-make ir0                  # kernel-x64.iso
-make run                  # QEMU
-make sync-mandocs         # install man pages → ~/.local/share/man (no sudo)
-make man TOPIC=onboarding # first-contributor guide (clone → first bug)
+make first-boot           # clone ../IR0-userspace if needed + minimal rootfs + ISO
+make run                  # QEMU GTK → getty → BusyBox ash
+```
+
+Kernel-only ISO (no shell): `make ir0`. Without `/sbin/init` on `disk.img` the
+kernel **panics** at handoff — there is no in-kernel fallback shell.
+
+```bash
+make sync-mandocs         # man pages → ~/.local/share/man (no sudo)
+make man TOPIC=onboarding
 make man TOPIC=boot
 ```
+
+Full coupling guide: **[Documentation/USERSPACE.md](Documentation/USERSPACE.md)**.
 
 | Profile | Meaning | Status |
 |---------|---------|--------|

--- a/SETUP.md
+++ b/SETUP.md
@@ -88,16 +88,35 @@ verbose ACPI/PCI wall. Requires QEMU `-virtfs` (wired by `run-bootlog` /
 ## Sibling userspace (required for product rootfs)
 
 Product PID1 (runit), BusyBox, login/doas, and `/etc` live in a **separate**
-repository. Clone it next to IR0:
+repository. **Recommended first-time path:**
+
+```bash
+make first-boot    # clones ../IR0-userspace if missing, builds rootfs, makes ISO
+make run           # QEMU → BusyBox ash (GTK)
+```
+
+Manual equivalent:
 
 ```bash
 git clone https://github.com/IRodriguez13/IR0-userspace.git ../IR0-userspace
 # or: export IR0_USERSPACE_ROOT=/path/to/IR0-userspace
 make check-userspace
 make headers_install DESTDIR=../IR0-userspace/out/sysroot
+make load-userspace-runit
+make kernel-x64-userspace.iso
 ```
 
-Full boundary and targets: [`Documentation/USERSPACE.md`](Documentation/USERSPACE.md)
+Optional in-guest TinyCC + GNU make (not required for BusyBox):
+
+```bash
+IR0_WITH_DEVTOOLS=1 make run
+# or: make load-userspace-devtools
+```
+
+**Boot without `/sbin/init`:** kernel `panic("Failed to load /sbin/init")`.
+**Init exits:** idle keeps the CPU; no userspace shell until reboot with a live PID1.
+
+Full boundary: [`Documentation/USERSPACE.md`](Documentation/USERSPACE.md)
 (Spanish: [`Documentation/esp/USERSPACE.md`](Documentation/esp/USERSPACE.md)).
 
 ## First-Time Configuration
@@ -149,11 +168,13 @@ make clean
 ### Graphical run (runit + getty/ash)
 
 ```bash
+make first-boot   # once: sibling + disk.img
 make run
 ```
 
-Builds `kernel-x64-userspace.iso`, injects runit + BusyBox into `disk.img`,
-and enables the standard IR0 hardware profile.
+Builds/uses `kernel-x64-userspace.iso`, injects runit + BusyBox into `disk.img`,
+and enables the standard IR0 hardware profile. Does **not** require TinyCC/GNU
+make unless `IR0_WITH_DEVTOOLS=1`.
 
 ### Serial-only (no GUI)
 

--- a/scripts/bootstrap-userspace.sh
+++ b/scripts/bootstrap-userspace.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# First-time wire-up: clone IR0-userspace (if missing), export UAPI, build
+# the minimal product rootfs (runit + BusyBox), inject into disk.img.
+#
+# Usage (from IR0 tree):
+#   ./scripts/bootstrap-userspace.sh
+#   make first-boot          # same + ISO
+#   make run                 # QEMU GTK (BusyBox ash via getty)
+#
+# Env:
+#   IR0_USERSPACE_ROOT   sibling path (default: ../IR0-userspace)
+#   IR0_USERSPACE_URL    clone URL
+#   IR0_PRODUCT_PROFILE  development|production (default: development)
+#   IR0_NO_AUTOLOGIN     0|1 (default: 0 for development)
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT}"
+
+USERSPACE_ROOT="${IR0_USERSPACE_ROOT:-${ROOT}/../IR0-userspace}"
+USERSPACE_URL="${IR0_USERSPACE_URL:-https://github.com/IRodriguez13/IR0-userspace.git}"
+PROFILE="${IR0_PRODUCT_PROFILE:-development}"
+NO_AUTOLOGIN="${IR0_NO_AUTOLOGIN:-0}"
+
+echo "=== IR0 ↔ IR0-userspace bootstrap ==="
+echo "  kernel:    ${ROOT}"
+echo "  userspace: ${USERSPACE_ROOT}"
+echo "  profile:   ${PROFILE}"
+
+if [ ! -f "${USERSPACE_ROOT}/Makefile" ]; then
+	parent="$(dirname "${USERSPACE_ROOT}")"
+	mkdir -p "${parent}"
+	echo "  CLONE    ${USERSPACE_URL} → ${USERSPACE_ROOT}"
+	git clone --depth 1 "${USERSPACE_URL}" "${USERSPACE_ROOT}"
+else
+	echo "  OK       sibling already present"
+fi
+
+export IR0_USERSPACE_ROOT="${USERSPACE_ROOT}"
+
+echo "  HEADERS  make headers_install → sibling sysroot"
+make -s headers_install DESTDIR="${USERSPACE_ROOT}/out/sysroot"
+
+echo "  CHECK    make check-userspace"
+make -s check-userspace
+
+echo "  ROOTFS   runit + BusyBox → disk.img (profile=${PROFILE})"
+IR0_PRODUCT_PROFILE="${PROFILE}" IR0_NO_AUTOLOGIN="${NO_AUTOLOGIN}" \
+	make -s load-userspace-runit
+
+echo "  ISO      kernel-x64-userspace.iso"
+make -s kernel-x64-userspace.iso
+
+cat <<EOF
+
+✓ Distro mínima lista (runit PID1 + BusyBox ash).
+
+Arrancar:
+  make run              # GTK + serial (recomendado)
+  make run-console      # solo serial (sin ventana)
+
+Dentro del guest (tras login / autologin development):
+  busybox
+  ls /
+  cat /proc/version
+  echo hello
+
+Toolchain in-guest (TinyCC + GNU make) es opcional:
+  make load-userspace-devtools   # o: IR0_WITH_DEVTOOLS=1 make run
+
+Docs: Documentation/USERSPACE.md
+EOF

--- a/userspace/README.md
+++ b/userspace/README.md
@@ -4,11 +4,18 @@ This directory is **not** a product rootfs. Unix userspace lives in the sibling 
 
 **https://github.com/IRodriguez13/IR0-userspace**
 
+First time from the kernel tree:
+
+```bash
+make first-boot && make run
+```
+
 | Env / target | Role |
 |--------------|------|
 | `IR0_USERSPACE_ROOT` | Path to the sibling (default: `../IR0-userspace`) |
+| `make first-boot` / `bootstrap-userspace` | Clone sibling if needed + minimal distro |
 | `make check-userspace` | Fail if sibling missing |
 | `make headers_install` | Export `includes/uapi/` for userspace builds |
-| `make build-runit` / `load-userspace-runit` | Delegate build/install to the sibling |
+| `make load-userspace-runit` | BusyBox + runit → `disk.img` |
 
 Full instructions: [`Documentation/USERSPACE.md`](../Documentation/USERSPACE.md).


### PR DESCRIPTION
## Summary
- Añade `make first-boot` / `scripts/bootstrap-userspace.sh` para clonar `IR0-userspace`, exportar UAPI e inyectar la distro mínima (runit + BusyBox).
- `make run` ya no exige TinyCC/GNU make; el toolchain in-guest queda en `IR0_WITH_DEVTOOLS=1`.
- Documenta el contrato de boot: panic sin `/sbin/init`; idle si init sale.
- Actualiza README, SETUP, USERSPACE (EN/ES) y onboarding.

## Test plan
- [ ] `make first-boot` con sibling ausente (clona y arma `disk.img`)
- [ ] `make run` arranca QEMU sin fallar en `build-gmake-static`
- [ ] En guest: `busybox`, `ls /`, `cat /proc/version`
- [ ] Opcional: `IR0_WITH_DEVTOOLS=1 make run` solo si hay musl-gcc

Nota: el PR #28 ya está merged; este commit va encima de `dev`. La rama se puede borrar al mergear desde GitHub (checkbox «Delete branch»).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are Makefile orchestration, a bootstrap script, and documentation only; no kernel runtime or security logic is modified in this diff.
> 
> **Overview**
> Introduces **`make first-boot`** (alias of **`bootstrap-userspace`**) and **`scripts/bootstrap-userspace.sh`** to clone **IR0-userspace** when missing, run **`headers_install`**, build the minimal runit + BusyBox rootfs, and produce **`kernel-x64-userspace.iso`**.
> 
> **`make run`**, **`run-debug`**, and **`run-fullscreen`** no longer always pull in TinyCC/GNU make; they default to **`load-userspace-runit`**, with in-guest toolchain only when **`IR0_WITH_DEVTOOLS=1`**. **`check-userspace`** failure text now points at **`make bootstrap-userspace`**.
> 
> Docs (**README**, **SETUP**, **USERSPACE** EN/ES, onboarding, pointers) are aligned on the first-boot flow, kernel-only **`make ir0`** vs product shell, and an explicit **boot contract**: panic if **`/sbin/init`** is missing or **`kexecve`** fails, idle (no automatic panic) if init exits, no in-kernel dbgshell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb17614b2da2441e04baaf04645dfb694a4ee99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->