### PR TITLE
Enhance userspace setup and decouple ISA architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2308,6 +2308,15 @@ load-userspace-runit: check-userspace build-runit build-busybox-ir0-auth build-o
 			if [ -e "$$dep" ] && [ "$$dep" -nt "$$STAMP" ]; then NEED=1; break; fi; \
 		done; \
 	fi; \
+	if [ $$NEED -eq 0 ] && [ "$${IR0_GUEST_MANDOCS:-1}" != "0" ]; then \
+		if [ -d "$$GUEST_MAN/usr/share/man/cat7" ] && \
+		   ls "$$GUEST_MAN/usr/share/man/cat7"/IR0-*.7 >/dev/null 2>&1; then \
+			if [ ! -f "$$GUEST_MAN/.stamp" ] || \
+			   [ "$$GUEST_MAN/.stamp" -nt "$$STAMP" ]; then \
+				NEED=1; \
+			fi; \
+		fi; \
+	fi; \
 	if [ $$NEED -eq 0 ]; then \
 		echo "  DISK    $$DISK up to date (cached runit rootfs — no reinject)"; \
 	else \

--- a/arch/common/arch_interface.c
+++ b/arch/common/arch_interface.c
@@ -447,7 +447,7 @@ void irq_init(void)
 
 void boot_irq_unmask(void)
 {
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 	/* PIC lines — x86 only; arm64 uses GIC PPIs via arch_irq_init. */
 	irq_unmask_line(0);
 	irq_unmask_line(1);

--- a/drivers/net/rtl8139.c
+++ b/drivers/net/rtl8139.c
@@ -663,6 +663,8 @@ static void rtl8139_check_tx_completion(void)
                     rtl8139_tx_descriptor_own_state[i] = 1;
                     rtl8139_tx_desc_start_tick[i] = 0;
                     rtl8139_tx_timeout_latched[i] = 0;
+                    /* Drop stale length so a later OWN edge cannot inflate tx_bytes. */
+                    rtl8139_tx_pending_len[i] = 0;
                     if (rtl8139_tx_in_flight > 0)
                         rtl8139_tx_in_flight--;
                     LOG_DEBUG_FMT("RTL8139", "TX descriptor %d force-released after timeout", i);

--- a/drivers/timer/clock_system.c
+++ b/drivers/timer/clock_system.c
@@ -96,7 +96,12 @@ static void clock_try_set_realtime_from_rtc(void)
 		return;
 	}
 	epoch = rtc_fields_to_unix(&rt);
-	if (epoch < 1000000000) /* before ~2001 — reject obvious garbage */
+	/*
+	 * Accept any civil year ≥ 1970 (including QEMU default 1970-01-01).
+	 * Reject only impossible conversions (rtc_fields_to_unix returns 0 with
+	 * zeroed day/month — still a valid epoch for 1970-01-01 00:00:00).
+	 */
+	if (rt.month == 0 || rt.day == 0)
 	{
 		clock_realtime_ok = 0;
 		return;

--- a/drivers/timer/rtc/rtc.c
+++ b/drivers/timer/rtc/rtc.c
@@ -151,7 +151,7 @@ void rtc_get_date_string(char *buffer, size_t buffer_size)
 		return;
 	}
 
-	full_year = (uint16_t)(time.century * 100 + (time.year % 100));
+	full_year = rtc_civil_year(&time);
 	buffer[0] = (char)('0' + (time.day / 10));
 	buffer[1] = (char)('0' + (time.day % 10));
 	buffer[2] = '/';

--- a/fs/pseudo_fs_nodes.c
+++ b/fs/pseudo_fs_nodes.c
@@ -223,17 +223,28 @@ static int sys_net_iface_match(const char *path, void **out_ctx)
 	if (!rest[0])
 		return -ENOENT;
 	slash = strchr(rest, '/');
-	if (!slash || !slash[1])
+	if (!slash)
+	{
+		/* /sys/class/net/<iface> — directory node (Linux sysfs). */
+		nlen = strlen(rest);
+		attr = SYS_NET_ATTR_DIR;
+	}
+	else if (!slash[1])
+	{
 		return -ENOENT;
-	nlen = (size_t)(slash - rest);
+	}
+	else
+	{
+		nlen = (size_t)(slash - rest);
+		attr = sys_class_net_parse_attr(slash + 1);
+		if (attr < 0)
+			return -ENOENT;
+	}
 	if (nlen == 0 || nlen >= sizeof(ifname))
 		return -ENOENT;
 	memcpy(ifname, rest, nlen);
 	ifname[nlen] = '\0';
 	if (sys_class_net_find_name(ifname) != 0)
-		return -ENOENT;
-	attr = sys_class_net_parse_attr(slash + 1);
-	if (attr < 0)
 		return -ENOENT;
 	ctx = sys_net_iface_ctx_alloc();
 	if (!ctx)
@@ -246,6 +257,27 @@ static int sys_net_iface_match(const char *path, void **out_ctx)
 	return 0;
 }
 
+static int sys_net_iface_stat(void *ctx, stat_t *st)
+{
+	sys_net_iface_ctx_t *file = ctx;
+
+	if (!file || !st)
+		return -EINVAL;
+	memset(st, 0, sizeof(*st));
+	if (file->attr == (unsigned)SYS_NET_ATTR_DIR)
+	{
+		st->st_mode = S_IFDIR | 0555;
+		st->st_nlink = 2;
+	}
+	else
+	{
+		st->st_mode = S_IFREG | 0444;
+		st->st_nlink = 1;
+		st->st_size = 4096;
+	}
+	return 0;
+}
+
 static int64_t sys_net_iface_read(void *ctx, char *buf, size_t count, off_t *offset)
 {
 	sys_net_iface_ctx_t *file = ctx;
@@ -253,6 +285,8 @@ static int64_t sys_net_iface_read(void *ctx, char *buf, size_t count, off_t *off
 	(void)offset;
 	if (!file || !buf)
 		return -EINVAL;
+	if (file->attr == (unsigned)SYS_NET_ATTR_DIR)
+		return -EISDIR;
 	return sys_class_net_attr_read_named(buf, count, file->ifname, file->attr);
 }
 
@@ -268,7 +302,7 @@ static int64_t sys_net_iface_close(void *ctx)
 static const pseudo_fs_ops_t sys_net_iface_ops = {
 	.read = sys_net_iface_read,
 	.close = sys_net_iface_close,
-	.stat = pseudo_default_stat,
+	.stat = sys_net_iface_stat,
 };
 
 static void pseudo_fs_register_sys_net_dynamic(void)

--- a/fs/sysfs.c
+++ b/fs/sysfs.c
@@ -825,7 +825,7 @@ int sysfs_write(int fd, const char *buf, size_t count)
 /* Get stat for /sys file */
 int sysfs_stat(const char *path, stat_t *st)
 {
-    const pseudo_fs_entry_t *pf;
+    int rc;
 
     if (!st || !is_sys_path(path))
         return -EINVAL;
@@ -838,12 +838,17 @@ int sysfs_stat(const char *path, stat_t *st)
         return 0;
     }
 
+    /*
+     * Use exact + dynamic resolution (same as open). Do not apply prefix
+     * static entries (e.g. /sys/class/net) to longer paths.
+     */
     pseudo_fs_nodes_register_all();
-    pf = pseudo_fs_lookup(path);
-    if (pf && pf->ops && pf->ops->stat)
-        return pf->ops->stat(pf->ctx, st);
+    rc = pseudo_fs_stat_path(path, st);
+    if (rc == 0)
+        return 0;
 
-    if (pseudo_fs_path_has_children(path))
+    if (pseudo_fs_path_has_children(path) ||
+	sys_class_net_path_has_children(path))
     {
         memset(st, 0, sizeof(*st));
         st->st_mode = S_IFDIR | 0555;
@@ -851,7 +856,7 @@ int sysfs_stat(const char *path, stat_t *st)
         return 0;
     }
 
-    return -ENOENT;  /* File not found */
+    return (rc < 0) ? rc : -ENOENT;
 }
 
 int sysfs_is_virtual_subdir(const char *path)
@@ -860,5 +865,7 @@ int sysfs_is_virtual_subdir(const char *path)
         return 0;
     if (strcmp(path, "/sys") == 0 || strcmp(path, "/sys/") == 0)
         return 1;
-    return pseudo_fs_path_has_children(path);
+    if (pseudo_fs_path_has_children(path))
+	return 1;
+    return sys_class_net_path_has_children(path);
 }

--- a/includes/ir0/rtc.h
+++ b/includes/ir0/rtc.h
@@ -38,6 +38,8 @@ uint8_t rtc_read_register(uint8_t reg);
 void rtc_write_register(uint8_t reg, uint8_t value);
 
 uint8_t rtc_bcd_to_binary(uint8_t bcd);
+/* Resolve century + year (or full year) to a Gregorian year ≥ 1970. */
+uint16_t rtc_civil_year(const rtc_time_t *rt);
 time_t rtc_fields_to_unix(const rtc_time_t *rt);
 void rtc_apply_cmos_format(rtc_time_t *time, uint8_t status_b);
 

--- a/includes/ir0/rtc_calendar.c
+++ b/includes/ir0/rtc_calendar.c
@@ -19,6 +19,25 @@ uint8_t rtc_bcd_to_binary(uint8_t bcd)
 	return (uint8_t)(((bcd >> 4) * 10) + (bcd & 0x0F));
 }
 
+uint16_t rtc_civil_year(const rtc_time_t *rt)
+{
+	uint16_t year;
+
+	if (!rt)
+		return 1970;
+
+	if (rt->century > 0 && rt->century < 100)
+		year = (uint16_t)(rt->century * 100 + (rt->year % 100));
+	else if (rt->year >= 1970)
+		year = rt->year;
+	else
+		year = (uint16_t)(2000 + (rt->year % 100));
+
+	if (year < 1970)
+		year = 1970;
+	return year;
+}
+
 /*
  * Convert civil date/time (UTC) to seconds since 1970-01-01.
  * Leap years: Gregorian. No leap seconds.
@@ -35,15 +54,7 @@ time_t rtc_fields_to_unix(const rtc_time_t *rt)
 	if (!rt)
 		return 0;
 
-	if (rt->century > 0 && rt->century < 100)
-		year = (uint16_t)(rt->century * 100 + (rt->year % 100));
-	else if (rt->year >= 1970)
-		year = rt->year;
-	else
-		year = (uint16_t)(2000 + (rt->year % 100));
-
-	if (year < 1970)
-		year = 1970;
+	year = rtc_civil_year(rt);
 
 	leap = (year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)) ? 1 : 0;
 

--- a/includes/ir0/sysfs.h
+++ b/includes/ir0/sysfs.h
@@ -64,9 +64,10 @@ int sys_class_net_collect_children(const char *dir_path,
 				   int start_n);
 int sys_class_net_path_has_children(const char *path);
 
-/* Attr ids for /sys/class/net/<iface>/ attributes */
+/* Attr ids for /sys/class/net/<iface>/… (0 = the iface directory itself). */
 enum
 {
+	SYS_NET_ATTR_DIR = 0,
 	SYS_NET_ATTR_NAME = 1,
 	SYS_NET_ATTR_ADDRESS = 2,
 	SYS_NET_ATTR_MTU = 3,

--- a/tests/host/test_rtc_calendar.c
+++ b/tests/host/test_rtc_calendar.c
@@ -26,10 +26,18 @@ void test_rtc_calendar(void)
 	t.hour = 12;
 	t.minute = 0;
 	t.second = 0;
+	ASSERT_EQ(rtc_civil_year(&t), 2026);
 	unix_t = rtc_fields_to_unix(&t);
 	/* 2026-07-26 12:00:00 UTC ≈ 1785067200 */
 	ASSERT_EQ((unix_t > 1700000000) ? 1 : 0, 1);
 	ASSERT_EQ((unix_t < 1900000000) ? 1 : 0, 1);
+
+	/* Full year in .year with century=0 (same as date-string path). */
+	memset(&t, 0, sizeof(t));
+	t.year = 2026;
+	t.month = 1;
+	t.day = 1;
+	ASSERT_EQ(rtc_civil_year(&t), 2026);
 
 	/* Leap day 2024-02-29 */
 	memset(&t, 0, sizeof(t));


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes sysfs stat/open semantics and kernel networking stats accounting; RTC validation is looser but still rejects invalid calendar fields.
> 
> **Overview**
> Improves **Linux-style `/sys/class/net`** handling: interface paths like `/sys/class/net/eth0` are exposed as **directories** (with proper `stat` and `EISDIR` on read), and **`sysfs_stat`** now resolves paths the same way as open (via `pseudo_fs_stat_path`) instead of mis-applying prefix static entries to longer paths. Virtual-directory detection also accounts for net interface children.
> 
> **RTC / wall clock** accepts QEMU’s default **1970-01-01** by validating only impossible month/day fields, not a minimum epoch; year display and Unix conversion share a new **`rtc_civil_year()`** helper (with host tests).
> 
> **RTL8139** clears pending TX length on descriptor timeout so recovered descriptors don’t **inflate `tx_bytes`**. **x86 boot** treats **`__amd64__`** like other x86 targets for early PIC unmask. **Makefile** invalidates cached guest disk images when guest **IR0 man pages** change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0625d2e6dcdda4899ec16b9192a19e02c012be87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->