### PR TITLE
feat(userspace): Dennis 9p, señales fatales, less/man y IR0-port

### DIFF
--- a/Documentation/USERSPACE.md
+++ b/Documentation/USERSPACE.md
@@ -130,6 +130,40 @@ Required serial tags (not frames-only): `DOOMGENERIC_MOUSE_CAPS_OK`, `DOOMGENERI
 
 PS/2 set-1 scancode `0x01` emits ASCII `0x1b` (`includes/ir0/ps2_set1.c`) so line-discipline apps (BusyBox `vi`) can leave insert/command modes. Host: `tests/host` → `ps2_set1 ESC make emits 0x1b`.
 
+### BusyBox `less` / `man` + fatal signal messages
+
+- Guest pages live under `/usr/share/man/cat7/*.7` (e.g. `man IR0` → `IR0.7`, not a file named `IR0`).
+- Default pager is `more` (`/etc/man.conf`); `less` needs working `poll`/`F_SETFL` (O_RDONLY is 0).
+- Product BusyBox: `FEATURE_LESS_MAXLINES=9999999`; `FEATURE_LESS_ASK_TERMINAL` off (no CSI `6n`).
+- Userspace SIGSEGV/FPE/ILL/BUS set `exit_signal` so `waitpid` is `WIFSIGNALED`; ash prints `"Segmentation fault"` (etc.) like Linux.
+
+### Doom + TTY
+
+While `/dev/events0` is open, keyboard EV_KEY still reaches Doom but cooked TTY input is diverted (avoids leftover `qqq`/`ls` in the shell). Doom exits cleanly (sound shutdown + TCFLSH) instead of `pause()` forever.
+
+### Dennis playground (kernel sources + dates)
+
+MINIX v1 cannot hold the full IR0 tree (file names ≤14 chars). Offline samples only:
+
+```text
+/heart/dennis/README
+/heart/dennis/src/hello.c
+/heart/dennis/src/Makefile
+```
+
+Full host tree (long names) is attached by QEMU and mounted in runit **stage1 as root**:
+
+| Piece | Role |
+|-------|------|
+| `make run` | `-virtfs …,mount_tag=dennis` (`IR0_DENNIS_9P=0` to skip) |
+| `/etc/runit/1` | `mount("dennis", "/heart/dennis/src", "9p", …)` before login |
+| Serial tags | `DENNIS_9P_MOUNT_OK` or `DENNIS_9P_MOUNT_SKIP` |
+| Guest check | `ls /heart/dennis/src/kernel` |
+
+`scripts/inject_init_minix.py` sets inode `mtime` from the host file (or `time.time()`), so `ls -l` no longer shows 1970-01-01 for freshly injected files.
+
+Porting checklist: `man IR0-port` (mandoc `Documentation/mandocs/en/porting.md`).
+
 ## Guest manuals (`man`) — Implemented
 
 BusyBox `man` + pre-rendered ASCII under `/usr/share/man/cat7/` (no `nroff`/`mandoc` in the guest). Host builds pages with `mandoc -Tascii` via `make prepare-guest-mandocs`; `load-userspace-runit` / `first-boot` inject them by default (`IR0_GUEST_MANDOCS=0` to skip).
@@ -141,12 +175,13 @@ MINIX v1 names are ≤14 characters, so two long host titles are shortened on di
 | IR0-boot | `IR0-boot` | `/usr/share/man/cat7/IR0-boot.7` |
 | IR0-userspace | `IR0-uspace` | `…/IR0-uspace.7` |
 | IR0-onboarding | `IR0-onboard` | `…/IR0-onboard.7` |
+| IR0-port | `IR0-port` | `…/IR0-port.7` |
 | IR0-vfs / syscalls / tty / process | same name | `…/IR0-<name>.7` |
 
 | Contract | State |
 |----------|--------|
 | `man IR0-boot` (readable text, not `.Sh` macros) | **Implemented** |
-| Subset above (7 pages) | **Implemented** |
+| Subset above (incl. `IR0-port`) | **Implemented** |
 | Full mandoc catalog / Spanish in guest | **Partial** — host `make sync-mandocs` / `man TOPIC=…` |
 | Generic Linux pages (`man ls`) | Out of scope |
 
@@ -154,6 +189,7 @@ MINIX v1 names are ≤14 characters, so two long host titles are shortened on di
 man IR0-boot
 man IR0-uspace
 man IR0-onboard
+man IR0-port
 man -w IR0-tty          # → /usr/share/man/cat7/IR0-tty.7
 ```
 

--- a/Documentation/esp/USERSPACE.md
+++ b/Documentation/esp/USERSPACE.md
@@ -72,16 +72,37 @@ Tags obligatorios: `DOOMGENERIC_MOUSE_CAPS_OK`, `DOOMGENERIC_AUDIO_OK`, `DOOMGEN
 
 Scancode PS/2 `0x01` → ASCII `0x1b` en `ps2_set1` (host test en `tests/host`).
 
+### BusyBox `less` / `man` + mensajes de señal
+
+- Páginas en `/usr/share/man/cat7/*.7` (`man IR0` → `IR0.7`, no un archivo `IR0`).
+- Pager por defecto: `more` (`/etc/man.conf`); `less` depende de `poll`/`F_SETFL` correctos.
+- `FEATURE_LESS_MAXLINES=9999999`; `FEATURE_LESS_ASK_TERMINAL` off.
+- SIGSEGV/etc. dejan `exit_signal` → ash imprime `"Segmentation fault"` como Linux.
+
+### Doom + TTY
+
+Con `/dev/events0` abierto, las teclas van a Doom (EV_KEY) pero no al TTY cocido (evita `qqqls` en ash). Doom sale con shutdown de audio + flush TTY (sin `pause()` infinito).
+
+### Dennis (fuentes del kernel + fechas)
+
+MINIX v1 no puede alojar el árbol completo (nombres ≤14). En disco solo hay muestras cortas bajo `/heart/dennis/src/` (`hello.c`, `Makefile`).
+
+El árbol host se monta en stage1 **como root** vía virtio-9p (`make run` → `mount_tag=dennis`). Tags: `DENNIS_9P_MOUNT_OK` / `SKIP`. Comprobar: `ls /heart/dennis/src/kernel`.
+
+`inject_init_minix.py` escribe `mtime` real (ya no 1970 en `ls -l` de archivos recién inyectados).
+
+Porteo a ISD: `man IR0-port`.
+
 ## Manuales en guest (`man`) — Implementado
 
 BusyBox `man` + páginas ASCII en `/usr/share/man/cat7/` (sin `nroff`/`mandoc` en el guest). El host las genera con `mandoc -Tascii` (`make prepare-guest-mandocs`); `load-userspace-runit` / `first-boot` las inyectan por defecto (`IR0_GUEST_MANDOCS=0` para omitir).
 
-MINIX v1 limita nombres a 14 caracteres: en guest usá `man IR0-uspace` y `man IR0-onboard` (contenido de IR0-userspace / IR0-onboarding).
+MINIX v1 limita nombres a 14 caracteres: en guest usá `man IR0-uspace`, `man IR0-onboard` y `man IR0-port`.
 
 | Contrato | Estado |
 |----------|--------|
 | `man IR0-boot` (texto legible) | **Implementado** |
-| Subset (7 páginas; alias cortos donde hace falta) | **Implementado** |
+| Subset (incl. `IR0-port`; alias cortos donde hace falta) | **Implementado** |
 | Catálogo completo / ES en guest | **Parcial** — en host: `make sync-mandocs` |
 | Páginas Linux genéricas (`man ls`) | Fuera de alcance |
 

--- a/Documentation/mandocs/en/INDEX.md
+++ b/Documentation/mandocs/en/INDEX.md
@@ -30,6 +30,7 @@ Start here: `make man TOPIC=onboarding`. Study subsystems via `man IR0-vfs`, etc
 | drivers | IR0-drivers | T0 | stable | `*_backend.h` |
 | process | IR0-process | T1 | stable | process / signals facades |
 | userspace | IR0-userspace | T1–T2 | stable | exec / ash helpers |
+| porting | IR0-port | T1 | stable | (ISD porting guide — guest `man IR0-port`) |
 | multi-arch | IR0-multi-arch | T0 | stable | `arch_port.h`, `arm64_board.h` |
 | net | IR0-net | T0 | stable | `net.h` |
 | interrupts | IR0-interrupts | T0 | stable | irq / arch port |

--- a/Documentation/mandocs/en/porting.md
+++ b/Documentation/mandocs/en/porting.md
@@ -1,0 +1,102 @@
+# Porting software to ISD (IR0 userspace)
+
+| Field | Value |
+|-------|-------|
+| Version | 0.1 |
+| IR0 phase | T1 |
+| Status | stable |
+| Depends on | userspace, syscalls, tty, vfs |
+| Man page | IR0-port (section 7) |
+| Primary sources | `Documentation/USERSPACE.md`, `IR0-userspace/`, `setup/pid1/`, TinyCC under `/lib/tcc` |
+
+> **Last verified:** 2026-07-28
+
+## 1. Overview
+
+**ISD** is the IR0 Software Distribution: BusyBox + runit + musl-linked
+tools on a MINIX rootfs, booted under the IR0 kernel. This page is a
+practical checklist for bringing a small C program (or BusyBox applet
+workflow) onto the guest.
+
+Out of scope: full glibc desktop ports, dynamic ELF without musl, or
+claiming Linux LTP parity.
+
+## 2. What works today
+
+| Capability | Notes |
+|------------|-------|
+| Static musl / TinyCC | `tcc -B/lib/tcc -static -Os …` |
+| BusyBox ash + applets | See `busybox --list` |
+| Files | MINIX v1 root; **names ≤14 characters** |
+| Editor | `vi` / `nano` (if injected) |
+| Kernel sources | `/heart/dennis/src` via virtio-9p (`make run`) |
+| Manuals | `man IR0-*` under `/usr/share/man/cat7/` |
+
+## 3. Compile on the guest
+
+```text
+cd /home/ivan/Escritorio/code   # or any writable dir
+cat > hello.c <<'EOF'
+#include <stdio.h>
+int main(void) { puts("hola"); return 0; }
+EOF
+tcc -B/lib/tcc -static -Os -o hello hello.c
+./hello
+```
+
+Rules:
+
+- Always pass `-B/lib/tcc` and prefer `-static`. Bare `tcc a.c -o a`
+  may emit a dynamic ELF that SEGV on IR0.
+- Keep object/binary basenames short if writing under MINIX paths
+  (`hello`, not `hello-world-debug`).
+
+## 4. Bring a host project in
+
+**Preferred (long names OK):** edit the host tree through Dennis:
+
+```text
+ls /heart/dennis/src/kernel/main.c
+# host path is the IR0 repo (QEMU -virtfs mount_tag=dennis)
+```
+
+Stage1 mounts this as root before login. If you only see `hello.c`,
+the 9p device is missing (`IR0_DENNIS_9P=0` or no virtio-9p).
+
+**Offline disk samples:** `/heart/dennis/src/hello.c` + `Makefile`
+(short names only).
+
+## 5. Syscall / libc expectations
+
+Target **musl Linux x86-64 ABI** as implemented by IR0:
+
+- Process: `fork`/`clone`, `execve`, `wait4`, signals (basic)
+- FS: `open`/`read`/`write`/`close`, `stat`, pipes, poll
+- Time: `nanosleep`, `clock_gettime` (subset)
+- Net: sockets exist; raw ICMP/`ping` may still be incomplete
+
+When something fails, compare with Linux ground-truth contracts in the
+kernel tree (`scripts/linux_abi/`) rather than guessing errno.
+
+## 6. Terminal and graphics apps
+
+- Line editors (`vi`, `less`/`more`, `man`) need a working TTY
+  (`TIOCGWINSZ`, cooked mode). Prefer `more` for paging if `less`
+  misbehaves.
+- Fullscreen apps (Doom-class): `/dev/fb0` + `/dev/events0`. While
+  `events0` is open, keyboard EV_KEY goes to the app — not the shell.
+
+## 7. Checklist before you claim “ported”
+
+1. Builds with `tcc -B/lib/tcc -static` (or musl-gcc on the host, then inject).
+2. Runs under ash without SEGV; ash prints signal names on fatal faults.
+3. Does not require glibc-only APIs or `/proc` layouts IR0 lacks.
+4. Paths fit MINIX if stored on the root disk (or live under 9p).
+5. Documented with a one-line smoke or `man` note if it becomes product.
+
+## 8. See also
+
+- `man IR0-uspace` — product userspace / ISD layout
+- `man IR0-syscalls` — syscall surface
+- `man IR0-onboard` — first clone / first boot
+- Host: `Documentation/USERSPACE.md`, sibling `IR0-userspace/`

--- a/Documentation/mandocs/esp/INDEX.md
+++ b/Documentation/mandocs/esp/INDEX.md
@@ -30,6 +30,7 @@ Empezá por: `make man TOPIC=onboarding`.
 | drivers | IR0-drivers | T0 | stable | `*_backend.h` |
 | process | IR0-process | T1 | stable | process / signals |
 | userspace | IR0-userspace | T1–T2 | stable | exec / ash |
+| porting | IR0-port | T1 | stable | portar a ISD / dennis 9p |
 | multi-arch | IR0-multi-arch | T0 | stable | `arch_port.h`, `arm64_board.h` |
 | net | IR0-net | T0 | stable | `net.h` |
 | interrupts | IR0-interrupts | T0 | stable | irq / arch port |

--- a/Documentation/mandocs/esp/porting.md
+++ b/Documentation/mandocs/esp/porting.md
@@ -1,0 +1,68 @@
+# Portar software a ISD (userspace IR0)
+
+| Field | Value |
+|-------|-------|
+| Version | 0.1 |
+| IR0 phase | T1 |
+| Status | stable |
+| Depends on | userspace, syscalls, tty, vfs |
+| Man page | IR0-port (sección 7) |
+| Primary sources | `Documentation/USERSPACE.md`, `IR0-userspace/`, TinyCC en `/lib/tcc` |
+
+> **Última verificación:** 2026-07-28
+
+## 1. Resumen
+
+**ISD** es la distribución de software de IR0: BusyBox + runit + herramientas
+enlazadas con musl sobre rootfs MINIX. Esta página es una guía práctica para
+traer un programa C pequeño (o un flujo BusyBox) al guest.
+
+Fuera de alcance: escritorios glibc completos, ELF dinámico sin musl, o
+paridad LTP.
+
+## 2. Qué funciona hoy
+
+| Capacidad | Notas |
+|-----------|-------|
+| musl / TinyCC estático | `tcc -B/lib/tcc -static -Os …` |
+| ash + applets BusyBox | `busybox --list` |
+| Archivos | MINIX v1; **nombres ≤14 caracteres** |
+| Fuentes del kernel | `/heart/dennis/src` vía virtio-9p (`make run`) |
+| Manuales | `man IR0-*` en `/usr/share/man/cat7/` |
+
+## 3. Compilar en el guest
+
+```text
+tcc -B/lib/tcc -static -Os -o hello hello.c
+./hello
+```
+
+Siempre `-B/lib/tcc` y preferí `-static`. Un `tcc a.c -o a` suelto puede
+generar ELF dinámico y SEGV.
+
+## 4. Traer un proyecto del host
+
+```text
+ls /heart/dennis/src/kernel/main.c
+```
+
+Stage1 monta el árbol IR0 del host (tag QEMU `dennis`) como root antes del
+login. Si solo ves `hello.c`, falta el dispositivo 9p.
+
+## 5. Expectativas ABI
+
+Orientate al ABI Linux x86-64 / musl que IR0 implementa. Ante divergencias,
+usá los contratos en `scripts/linux_abi/`.
+
+## 6. Checklist
+
+1. Compila con TinyCC estático (o musl-gcc en host + inject).
+2. Corre bajo ash sin SEGV.
+3. No exige APIs solo-glibc.
+4. Rutas cortas en disco MINIX (o viví bajo 9p).
+5. Documentá un smoke breve si entra al producto.
+
+## 7. Ver también
+
+`man IR0-uspace`, `man IR0-syscalls`, `man IR0-onboard`,
+`Documentation/USERSPACE.md`.

--- a/Makefile
+++ b/Makefile
@@ -2336,7 +2336,8 @@ load-userspace-runit: check-userspace build-runit build-busybox-ir0-auth build-o
 	if [ ! -f "$$DISK" ] || [ ! -f "$$STAMP" ]; then NEED=1; fi; \
 	if [ $$NEED -eq 0 ] && [ "$$(cat "$$STAMP" 2>/dev/null)" != "$$PROFILE" ]; then NEED=1; fi; \
 	if [ $$NEED -eq 0 ]; then \
-		for dep in $(RUNIT_BIN_DIR)/runit-init $(RUNIT_STAGE_BIN)/runit_console_run \
+		for dep in $(RUNIT_BIN_DIR)/runit-init $(RUNIT_STAGE_BIN)/runit_stage1 \
+			$(RUNIT_STAGE_BIN)/runit_console_run \
 			$(RUNIT_STAGE_BIN)/ir0_passwd $(RUNIT_STAGE_BIN)/doas \
 			$(RUNIT_STAGE_BIN)/nano \
 			$(IR0_USERSPACE_ROOT)/rootfs/etc/passwd \

--- a/fs/devfs.c
+++ b/fs/devfs.c
@@ -2245,10 +2245,27 @@ static int64_t dev_events0_ioctl(devfs_entry_t *entry, uint64_t request, void *a
     return -EINVAL;
 }
 
+static int64_t dev_events0_open(devfs_entry_t *entry, int flags)
+{
+	(void)entry;
+	(void)flags;
+	input_events_reader_open();
+	return 0;
+}
+
+static int64_t dev_events0_close(devfs_entry_t *entry)
+{
+	(void)entry;
+	input_events_reader_close();
+	return 0;
+}
+
 static const devfs_ops_t events0_ops = {
     .read = dev_events0_read,
     .write = NULL,
     .ioctl = dev_events0_ioctl,
+    .open = dev_events0_open,
+    .close = dev_events0_close,
     .can_read = devfs_events0_can_read,
     .can_write = devfs_events0_can_write,
 };
@@ -3054,8 +3071,16 @@ int64_t devfs_close_node(devfs_node_t *node)
 
     node->ref_count--;
     rc = 0;
-    if (node->ref_count == 0 && node->ops && node->ops->close)
-        rc = node->ops->close(&node->entry);
+    if (node->ops && node->ops->close)
+    {
+        /*
+         * events0: per-fd release (reader divert count).
+         * Other devices: last-close teardown only.
+         */
+        if (node == &dev_events0 || node == &dev_input_event0 ||
+            node->ref_count == 0)
+            rc = node->ops->close(&node->entry);
+    }
 
     return rc;
 }

--- a/includes/ir0/input.h
+++ b/includes/ir0/input.h
@@ -185,6 +185,14 @@ struct input_event {
 /* Push event from keyboard IRQ (kernel/input_events.c) */
 void input_event_push(uint16_t type, uint16_t code, int32_t value);
 
+/*
+ * /dev/events0 open-reader count. While >0, PS/2 still feeds EV_KEY but
+ * must not also inject cooked TTY bytes (Doom dual-delivery → "qqqls").
+ */
+void input_events_reader_open(void);
+void input_events_reader_close(void);
+int input_events_readers_active(void);
+
 /* Read events (devfs /dev/events0) */
 size_t input_event_read(struct input_event *buf, size_t count);
 int input_event_has_data(void);

--- a/includes/ir0/signals.c
+++ b/includes/ir0/signals.c
@@ -376,8 +376,12 @@ void handle_signals(void)
 #if DEBUG_PROCESS
             klog_info("SIGNAL", "SIGSEGV received (segmentation fault), terminating process");
 #endif
-            current->signal_pending &= ~SIGNAL_MASK(SIGSEGV);
-            process_exit(139);
+            if (!process_signal_default_kill(current, SIGSEGV))
+            {
+                current->signal_pending &= ~SIGNAL_MASK(SIGSEGV);
+                current->exit_signal = SIGSEGV;
+                process_exit(0);
+            }
             return;
         }
     }
@@ -389,8 +393,12 @@ void handle_signals(void)
 #if DEBUG_PROCESS
             klog_info("SIGNAL", "SIGFPE received (arithmetic error), terminating process");
 #endif
-            current->signal_pending &= ~SIGNAL_MASK(SIGFPE);
-            process_exit(136);
+            if (!process_signal_default_kill(current, SIGFPE))
+            {
+                current->signal_pending &= ~SIGNAL_MASK(SIGFPE);
+                current->exit_signal = SIGFPE;
+                process_exit(0);
+            }
             return;
         }
     }
@@ -402,8 +410,12 @@ void handle_signals(void)
 #if DEBUG_PROCESS
             klog_info("SIGNAL", "SIGILL received (illegal instruction), terminating process");
 #endif
-            current->signal_pending &= ~SIGNAL_MASK(SIGILL);
-            process_exit(132);
+            if (!process_signal_default_kill(current, SIGILL))
+            {
+                current->signal_pending &= ~SIGNAL_MASK(SIGILL);
+                current->exit_signal = SIGILL;
+                process_exit(0);
+            }
             return;
         }
     }
@@ -415,8 +427,12 @@ void handle_signals(void)
 #if DEBUG_PROCESS
             klog_info("SIGNAL", "SIGBUS received (bus error), terminating process");
 #endif
-            current->signal_pending &= ~SIGNAL_MASK(SIGBUS);
-            process_exit(135);
+            if (!process_signal_default_kill(current, SIGBUS))
+            {
+                current->signal_pending &= ~SIGNAL_MASK(SIGBUS);
+                current->exit_signal = SIGBUS;
+                process_exit(0);
+            }
             return;
         }
     }
@@ -470,7 +486,8 @@ void handle_signals(void)
             klog_info("SIGNAL", "SIGINT received, terminating process");
 #endif
             current->signal_pending &= ~SIGNAL_MASK(SIGINT);
-            process_exit(130); /* 128 + SIGINT */
+            current->exit_signal = SIGINT;
+            process_exit(0);
             return;
         }
         /* else: fall through to userspace handler delivery below */
@@ -504,7 +521,8 @@ void handle_signals(void)
             klog_info("SIGNAL", "SIGQUIT received, terminating process");
 #endif
             current->signal_pending &= ~SIGNAL_MASK(SIGQUIT);
-            process_exit(131); /* 128 + SIGQUIT */
+            current->exit_signal = SIGQUIT;
+            process_exit(0);
             return;
         }
     }
@@ -515,7 +533,8 @@ void handle_signals(void)
         klog_info("SIGNAL", "SIGABRT received, terminating process");
 #endif
         current->signal_pending &= ~SIGNAL_MASK(SIGABRT);
-        process_exit(134); /* Exit code 134 = 128 + 6 (SIGABRT) */
+        current->exit_signal = SIGABRT;
+        process_exit(0);
         return;
     }
 

--- a/interrupt/arch/keyboard.c
+++ b/interrupt/arch/keyboard.c
@@ -319,7 +319,12 @@ static void keyboard_feed_scancode(uint8_t scancode)
 			kbd_scancode_tag = 1;
 			klog_smoke("KBD_SCANCODE_OK");
 		}
-		keyboard_buffer_add_bytes(r.emitted, r.emitted_len);
+		/*
+		 * While /dev/events0 has readers (Doom, etc.), only EV_KEY —
+		 * do not also inject ASCII into the cooked TTY line (qqqls).
+		 */
+		if (!input_events_readers_active())
+			keyboard_buffer_add_bytes(r.emitted, r.emitted_len);
 	}
 }
 

--- a/kernel/input_events.c
+++ b/kernel/input_events.c
@@ -19,6 +19,7 @@
 #include <ir0/input.h>
 #include <ir0/time.h>
 #include <ir0/clock.h>
+#include <ir0/console.h>
 #include <string.h>
 #include <ir0/arch_port.h>
 
@@ -27,6 +28,7 @@
 static struct input_event event_queue[INPUT_EVENT_QUEUE_SIZE];
 static volatile unsigned int ev_head;
 static volatile unsigned int ev_tail;
+static volatile int events_readers;
 
 static inline uint64_t input_events_irq_save(void)
 {
@@ -36,6 +38,32 @@ static inline uint64_t input_events_irq_save(void)
 static inline void input_events_irq_restore(uint64_t flags)
 {
 	irq_restore((unsigned long)flags);
+}
+
+void input_events_reader_open(void)
+{
+	uint64_t irq_flags = input_events_irq_save();
+
+	events_readers++;
+	input_events_irq_restore(irq_flags);
+}
+
+void input_events_reader_close(void)
+{
+	int do_flush = 0;
+	uint64_t irq_flags = input_events_irq_save();
+
+	if (events_readers > 0)
+		events_readers--;
+	do_flush = (events_readers == 0);
+	input_events_irq_restore(irq_flags);
+	if (do_flush)
+		ir0_console_flush_input();
+}
+
+int input_events_readers_active(void)
+{
+	return events_readers > 0;
 }
 
 /* Called from keyboard IRQ handler - must be fast, no blocking */

--- a/kernel/process/signals.c
+++ b/kernel/process/signals.c
@@ -23,11 +23,14 @@ int process_signal_is_default_fatal(process_t *p, int sig)
 	if (sig == SIGKILL)
 		return 1;
 	/*
-	 * Default action Terminate (Linux signal(7)). Include USR1/USR2 —
-	 * BusyBox halt/poweroff signal init with those when not using -f.
+	 * Default action Terminate (Linux signal(7)). Include:
+	 * - USR1/USR2 — BusyBox halt/poweroff when not using -f
+	 * - SEGV/FPE/ILL/BUS/ABRT — so wait status is WIFSIGNALED (ash
+	 *   prints "Segmentation fault", etc.)
 	 */
 	if (sig != SIGTERM && sig != SIGHUP && sig != SIGINT && sig != SIGQUIT &&
-	    sig != SIGUSR1 && sig != SIGUSR2)
+	    sig != SIGUSR1 && sig != SIGUSR2 && sig != SIGSEGV && sig != SIGFPE &&
+	    sig != SIGILL && sig != SIGBUS && sig != SIGABRT)
 		return 0;
 	if (p->signal_ignored & SIGNAL_MASK(sig))
 		return 0;

--- a/kernel/syscalls/io_syscalls.c
+++ b/kernel/syscalls/io_syscalls.c
@@ -127,7 +127,11 @@ int fd_can_read_for(process_t *proc, int fd)
     return ir0_eventfd_poll_readable((struct ir0_eventfd *)fd_table[fd].vfs_file);
   if (fd_table[fd].is_timerfd && fd_table[fd].vfs_file)
     return ir0_timerfd_poll_readable((struct ir0_timerfd *)fd_table[fd].vfs_file);
-  if (fd_table[fd].flags & (O_RDONLY | O_RDWR))
+  /*
+   * Regular VFS / redirected files: poll-readable unless write-only.
+   * O_RDONLY is 0 — never use `flags & O_RDONLY` (always false).
+   */
+  if ((fd_table[fd].flags & O_ACCMODE) != O_WRONLY)
     return 1;
   return 0;
 }
@@ -1557,11 +1561,16 @@ int64_t sys_fcntl(int fd, int cmd, unsigned long arg)
     return fd_table[fd].flags;
   case F_SETFL:
     /*
-     * Accept O_NONBLOCK etc. Do not honor O_ASYNC/FASYNC: IR0 has no
-     * SIGIO delivery on poll-ready, and TinyX KdAddFd would otherwise
-     * arm handlers that re-enter MouseRead/KeyboardRead unsafely.
+     * Linux: preserve O_ACCMODE; only status flags are mutable.
+     * Do not honor O_ASYNC/FASYNC (no SIGIO). Clobbering access mode
+     * broke BusyBox less (ndelay_on → flags became O_NONBLOCK alone).
      */
-    fd_table[fd].flags = (int)(arg & ~(unsigned long)O_ASYNC);
+    {
+      int keep = fd_table[fd].flags & O_ACCMODE;
+      int settable = (int)arg & (O_APPEND | O_NONBLOCK);
+
+      fd_table[fd].flags = keep | settable;
+    }
     return 0;
   case F_GETOWN:
     return current_process->task.pid;

--- a/mm/page_fault.c
+++ b/mm/page_fault.c
@@ -332,8 +332,15 @@ static void pf_user_segv(process_t *p, uint64_t *stack, uint64_t fault_addr,
 			(unsigned)(p->signal_mask),
 			(unsigned)(p->signal_ignored));
 
-	(void)send_signal(p->task.pid, SIGSEGV);
-	process_exit(128 + SIGSEGV);
+	/*
+	 * Linux wait status must be WIFSIGNALED(SIGSEGV), not exited(139).
+	 * Ash prints "Segmentation fault" only when exit_signal is set.
+	 */
+	if (!process_signal_default_kill(p, SIGSEGV))
+	{
+		p->exit_signal = SIGSEGV;
+		process_exit(0);
+	}
 }
 
 void mm_page_fault_handle(const struct arch_page_fault_info *info, void *irq_frame)
@@ -519,8 +526,11 @@ void mm_page_fault_handle(const struct arch_page_fault_info *info, void *irq_fra
 			       (unsigned)(current ? (uint32_t)current->task.pid : 0));
 		if (current && current->mode == USER_MODE)
 		{
-			(void)send_signal(current->task.pid, SIGSEGV);
-			process_exit(128 + SIGSEGV);
+			if (!process_signal_default_kill(current, SIGSEGV))
+			{
+				current->exit_signal = SIGSEGV;
+				process_exit(0);
+			}
 		}
 		panic("Unhandled kernel page fault (uaccess, no user task)");
 	}

--- a/scripts/build_mandocs.py
+++ b/scripts/build_mandocs.py
@@ -156,6 +156,13 @@ MANDOC_CHAPTERS: list[MandocChapter] = [
         "BusyBox, runit, musl, TCC y bootstrap DoomGeneric",
     ),
     MandocChapter(
+        "porting",
+        "porting.md",
+        "IR0-port",
+        "Porting small C programs and tools onto ISD",
+        "Portar programas C y herramientas pequenas a ISD",
+    ),
+    MandocChapter(
         "multi-arch",
         "multi-arch.md",
         "IR0-multi-arch",

--- a/scripts/inject_dennis_src_minix.sh
+++ b/scripts/inject_dennis_src_minix.sh
@@ -3,8 +3,9 @@
 #
 # Stage Dennis Ritchie playground under /heart/dennis on MINIX disk.img:
 #   README + short-name samples (MINIX v1 name ≤14 chars).
-# Full IR0 tree (long names) is mounted at runtime via virtio-9p tag "dennis":
+# Full IR0 tree (long names) is mounted at boot by runit stage1:
 #   mount -t 9p dennis /heart/dennis/src
+# (QEMU: make run attaches -virtfs mount_tag=dennis)
 #
 # Usage: inject_dennis_src_minix.sh [disk.img]
 
@@ -31,23 +32,33 @@ mkdir -p "${STAGE}/heart/dennis/src"
 cat > "${STAGE}/heart/dennis/README" <<'EOF'
 Dennis Ritchie playground — IR0 sources for editors & toolchain.
 
-Offline (MINIX, short names):
+Full kernel/userspace tree (host IR0 via virtio-9p):
+  ls /heart/dennis/src
+  ls /heart/dennis/src/kernel
+  nano /heart/dennis/src/kernel/main.c
+
+runit stage1 mounts tag "dennis" as root before login
+(QEMU: make run → -virtfs mount_tag=dennis). Look for
+serial tag DENNIS_9P_MOUNT_OK. If you only see hello.c,
+the 9p device is missing (IR0_DENNIS_9P=0).
+
+Offline samples on the MINIX disk (short names, ≤14 chars):
   /heart/dennis/src/hello.c
   /heart/dennis/src/Makefile
 
-Full tree (host IR0 via virtio-9p — long filenames OK):
-  mount -t 9p dennis /heart/dennis/src
-  ls /heart/dennis/src
-  nano /heart/dennis/src/kernel/main.c
+Build sample with TinyCC:
   tcc -B/lib/tcc -static -o /tmp/hi /heart/dennis/src/hello.c
 
-QEMU: make run attaches -virtfs mount_tag=dennis (IR0_DENNIS_9P=0 to skip).
+Porting tips: man IR0-port
 EOF
 
 cat > "${STAGE}/heart/dennis/src/hello.c" <<'EOF'
 /* Minimal C sample for nano/vi + tcc on IR0. */
+#include <stdio.h>
+
 int main(void)
 {
+	puts("hello from /heart/dennis");
 	return 0;
 }
 EOF
@@ -68,7 +79,8 @@ EOF
 
 cat > "${STAGE}/heart/dennis/src/NOTES.txt" <<'EOF'
 Short-name files only fit on MINIX v1 (14-char names).
-Mount 9p tag dennis over this directory for the full IR0 tree.
+Full IR0 tree appears here after stage1 9p mount (dennis).
+See /heart/dennis/README and: man IR0-port
 EOF
 
 echo "  DENNIS  /heart/dennis (README + src samples)"

--- a/scripts/inject_init_minix.py
+++ b/scripts/inject_init_minix.py
@@ -22,6 +22,7 @@ Usage:
 import os
 import struct
 import sys
+import time
 
 BLOCK = 1024
 INODE_SIZE = 32
@@ -31,6 +32,16 @@ MAGIC = 0x137F
 IFDIR = 0o040000
 IFREG = 0o100000
 IFMT = 0o170000
+
+
+def now_mtime(path=None):
+    """Unix time for MINIX v1 inode mtime (avoid epoch 1970 on ls -l)."""
+    if path:
+        try:
+            return int(os.stat(path).st_mtime) & 0xFFFFFFFF
+        except OSError:
+            pass
+    return int(time.time()) & 0xFFFFFFFF
 
 
 def inject_verbose():
@@ -421,7 +432,7 @@ def format_minix_v1(f, ninodes=64, nzones=1024):
         "mode": IFDIR | 0o755,
         "uid": 0,
         "size": 2 * DIR_ENTRY,
-        "mtime": 0,
+        "mtime": now_mtime(),
         "gid": 0,
         "nlinks": 2,
         "zones": [root_zone] + [0] * 8,
@@ -489,7 +500,7 @@ def mkdir(f, sb, parent_num, parent, name, parent_prefix):
         "mode": mode,
         "uid": 0,
         "size": 2 * DIR_ENTRY,
-        "mtime": 0,
+        "mtime": now_mtime(),
         "gid": 0,
         "nlinks": 2,
         "zones": [zone] + [0] * 8,
@@ -626,7 +637,7 @@ def write_file(f, sb, path_parts, data, source_path, file_mode=0o755,
                     "mode": IFREG | file_mode,
                     "uid": 0,
                     "size": 0,
-                    "mtime": 0,
+                    "mtime": now_mtime(source_path),
                     "gid": 0,
                     "nlinks": 1,
                     "zones": [0] * 9,
@@ -638,13 +649,14 @@ def write_file(f, sb, path_parts, data, source_path, file_mode=0o755,
                         "mode": IFREG | file_mode,
                         "uid": 0,
                         "size": 0,
-                        "mtime": 0,
+                        "mtime": now_mtime(source_path),
                         "gid": 0,
                         "nlinks": 1,
                         "zones": [0] * 9,
                     }
 
             file_inode = prepare_regular_file(f, sb, file_inode, data, file_mode)
+            file_inode["mtime"] = now_mtime(source_path)
             if owner is not None:
                 file_inode["uid"], file_inode["gid"] = owner
             audit_entry(
@@ -710,9 +722,15 @@ def hardlink_path(f, sb, existing_parts, new_parts):
             if existing != 0:
                 if existing == src_ino:
                     return src_ino
-                raise SystemExit(
-                    "hardlink dest already exists: /" + "/".join(new_parts)
-                )
+                # Replace stale applet name (e.g. BusyBox reinject): detach
+                # the old directory entry so the hardlink can point at the
+                # new multicall inode.
+                old = read_inode(f, sb, existing)
+                remove_dir_entry(f, sb, cur, cur_num, part)
+                if old.get("nlinks", 1) > 1:
+                    old["nlinks"] = max(1, old["nlinks"] - 1)
+                    write_inode(f, sb, existing, old)
+                existing = 0
             add_dir_entry(f, sb, cur, cur_num, part, src_ino)
             src["nlinks"] = min(255, src["nlinks"] + 1)
             write_inode(f, sb, src_ino, src)

--- a/scripts/prepare_guest_mandocs.sh
+++ b/scripts/prepare_guest_mandocs.sh
@@ -30,6 +30,7 @@ DEFAULT_PAGE_MAP=(
 	"IR0-boot"
 	"IR0-userspace IR0-uspace"
 	"IR0-onboarding IR0-onboard"
+	"IR0-port"
 	"IR0-vfs"
 	"IR0-syscalls"
 	"IR0-tty"
@@ -115,7 +116,8 @@ done
 		"PAGES ON THIS SYSTEM" \
 		"       man IR0-boot      boot and bring-up" \
 		"       man IR0-uspace    userspace and ISD" \
-		"       man IR0-onboard   onboarding" \
+		"       man IR0-port      porting software to ISD" \
+		"       man IR0-onboard   first boot / onboarding" \
 		"       man IR0-vfs       VFS" \
 		"       man IR0-syscalls  syscalls" \
 		"       man IR0-tty       TTY" \

--- a/setup/doom/doomgeneric_ir0.c
+++ b/setup/doom/doomgeneric_ir0.c
@@ -1077,21 +1077,27 @@ int main(int argc, char **argv)
     if (g_fd_input >= 0)
     {
         close(g_fd_input);
+        g_fd_input = -1;
     }
+    IR0_SoundShutdown();
     if (g_fb_map && g_fb_map != MAP_FAILED)
     {
         (void)munmap(g_fb_map, g_fb_len);
+        g_fb_map = NULL;
     }
     if (g_fd_fb >= 0)
     {
         close(g_fd_fb);
+        g_fd_fb = -1;
     }
 
 #ifdef FASE55E_INTERACTIVE
-    for (;;)
-    {
-        (void)pause();
-    }
+    /*
+     * Drop leftover cooked-TTY bytes that arrived before events0 divert
+     * (or if divert was unavailable). TCFLSH = 0x540B, TCIFLUSH = 0.
+     */
+    (void)ioctl(STDIN_FILENO, 0x540Bu, 0);
+    write_str("DOOMGENERIC_INTERACTIVE_EXIT_OK\n");
 #endif
 
     return 0;

--- a/setup/make/legacy-smokes.mk
+++ b/setup/make/legacy-smokes.mk
@@ -136,18 +136,19 @@ smoke-userspace-shell: load-userspace-rootfs kernel-x64-userspace.iso
 	fi
 
 smoke-userspace-segv: build-init-segv-smoke build-userspace-segv kernel-x64-userspace.iso
-	@echo "  SMOKE   userspace #PF -> SIGSEGV (PID1 wait4)..."
+	@echo "  SMOKE   userspace #PF -> WIFSIGNALED(SIGSEGV) (PID1 wait4)..."
 	@DISK=$$(mktemp /tmp/ir0-userspace-disk.XXXXXX.img); \
 	cp -f disk.img $$DISK; \
 	python3 scripts/inject_init_minix.py $$DISK $(INIT_SMOKE_BIN) sbin/init; \
 	python3 scripts/inject_init_minix.py $$DISK $(SEGV_SMOKE_BIN) bin/userspace_segv; \
-	$(SMOKE_QEMU_RUN) --log /tmp/userspace-segv-smoke.log --timeout 90 --done code=000000000000008B -- \
+	$(SMOKE_QEMU_RUN) --log /tmp/userspace-segv-smoke.log --timeout 90 \
+		--done "userspace_segv smoke observed" -- \
 		$(QEMU) -cdrom kernel-x64-userspace.iso \
 		-drive file=$$DISK,format=raw,if=ide,index=0 \
 		-serial stdio -display none -m 128M -no-reboot -net none; \
 	rm -f $$DISK;
 	@if grep -q "\\[PF\\] userspace segv pid=" /tmp/userspace-segv-smoke.log && \
-	    grep -q "\\[PROCESS\\] exit pid=.*code=000000000000008B" /tmp/userspace-segv-smoke.log; then \
+	    grep -q "userspace_segv smoke observed" /tmp/userspace-segv-smoke.log; then \
 		echo "✓ smoke-userspace-segv passed"; \
 	else \
 		echo "✗ smoke-userspace-segv FAILED"; \

--- a/setup/pid1/init_segv_smoke.c
+++ b/setup/pid1/init_segv_smoke.c
@@ -1,14 +1,18 @@
 /* SPDX-License-Identifier: GPL-3.0-only */
 /*
- * PID1 smoke for userspace #PF -> SIGSEGV-equivalent exit.
+ * PID1 smoke for userspace #PF -> WIFSIGNALED(SIGSEGV) wait status.
+ * Linux ash prints "Segmentation fault" only when exit_signal is set
+ * (not exited(139)).
  */
 
+#include <signal.h>
 #include <unistd.h>
 #include <sys/wait.h>
 
 int main(void)
 {
 	pid_t pid = fork();
+	int status = 0;
 
 	if (pid == 0)
 	{
@@ -25,12 +29,24 @@ int main(void)
 		return 1;
 	}
 
+	if (wait4(pid, &status, 0, 0) < 0)
 	{
-		(void)wait4(pid, 0, 0, 0);
+		static const char msg[] = "IR0: userspace_segv: wait4 failed\n";
+		write(2, msg, sizeof(msg) - 1);
+		return 2;
+	}
+
+	if (!WIFSIGNALED(status) || WTERMSIG(status) != SIGSEGV)
+	{
+		static const char msg[] =
+			"IR0: userspace_segv: expected WIFSIGNALED(SIGSEGV)\n";
+		write(2, msg, sizeof(msg) - 1);
+		return 3;
+	}
+
+	{
 		static const char ok[] = "IR0: userspace_segv smoke observed\n";
 		write(1, ok, sizeof(ok) - 1);
 		return 0;
 	}
-
-	return 4;
 }


### PR DESCRIPTION
## Summary
- Montaje virtio-9p `dennis` → `/heart/dennis/src` (docs + inject mtime + stamp `runit_stage1`)
- Manpage `IR0-port` (porteo a ISD) + USERSPACE EN/ES
- Señales fatales con `exit_signal`, poll/`F_SETFL` para less, desvío TTY con Doom/`events0`

## Test plan
- [x] QEMU: `DENNIS_9P_MOUNT_OK` + `RUNIT_STAGE1_OK`
- [x] Inject: `hello.c` mtime ≠ 1970
- [ ] Guest: `ls /heart/dennis/src/kernel` y `man IR0-port` tras `make run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default fatal signal and page-fault termination semantics plus poll/ioctl behavior used by BusyBox; smoke tests were updated but any custom wait-status assumptions could break.
> 
> **Overview**
> Improves ISD userspace behavior and documents the Dennis virtio-9p workflow, guest `man IR0-port`, and related product contracts in **USERSPACE** (EN/ES) plus new **porting** mandoc chapters.
> 
> **Fatal signals** now set `exit_signal` and exit with code 0 (via `process_signal_default_kill` where applicable) instead of `process_exit(128+sig)`, so `waitpid` reports **WIFSIGNALED** and ash prints messages like `"Segmentation fault"`. Page-fault and default signal paths are aligned; the SEGV smoke checks `WIFSIGNALED(SIGSEGV)`.
> 
> **BusyBox `less` / `man`:** `poll` treats read-only fds as pollable using `O_ACCMODE` (since `O_RDONLY` is 0), and **`F_SETFL`** only updates `O_APPEND`/`O_NONBLOCK` while preserving access mode.
> 
> **Doom + TTY:** `/dev/events0` tracks open readers; while any reader is active, PS/2 still queues **EV_KEY** but skips injecting cooked TTY bytes; closing the last reader flushes console input. Doom shuts down audio, unmaps FB, and **TCIFLUSH** stdin instead of hanging in `pause()`.
> 
> **Disk inject:** MINIX inode **mtime** comes from the host file (or current time); Dennis inject README reflects stage1 9p mount; **`load-userspace-runit`** stamp depends on **`runit_stage1`**; guest mandoc pipeline adds **`IR0-port`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84690993b99678476c7cba9c23a29cdc022c2fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->