### PR TITLE
fix(first-boot): deps portables sin Rust obligatorio y con yacc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1612,7 +1612,8 @@ RUNIT_ASH_SMOKE_LOG = /tmp/runit-ash-smoke.log
 DOOM_FRAMES ?= 0
 DOOM_FRAME_DUMP_EVERY ?= 0
 DOOM_DISPLAY ?= gtk
-REAL_WAD_PATH ?= /home/ivanr013/Escritorio/universal-doom/DOOM1.WAD
+# Optional Doom IWAD for ken/games and legacy smokes (no maintainer home path).
+REAL_WAD_PATH ?=
 FASE52_TCC_STAGE = setup/pid1/fase52_staging
 FASE50_PROGRAMS_LOG = /tmp/userspace-fase50-programs.log
 # Serial-log autokill: scripts/smoke_autokill.py (default max 180s; heavy smokes use --profile 90–120s).

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Product userspace (runit + BusyBox) lives in a **sibling repo**. First boot:
 git clone https://github.com/IRodriguez13/IR0.git
 cd IR0
 make check-env            # host diagnostic (or: make first-boot asks to install missing deps)
-make defconfig
-make first-boot           # clone ../IR0-userspace if needed + minimal rootfs + ISO
+make first-boot           # defconfig if needed + clone ../IR0-userspace + rootfs + ISO
 make run                  # QEMU GTK → getty → BusyBox ash
 ```
+
+`make first-boot` does not require Rust nightly (only if you enable example drivers in menuconfig). Host needs musl-tools, bison (`yacc`), git, curl, and the usual desktop ISO toolchain — see [SETUP.md](SETUP.md).
 
 Kernel-only ISO (no shell): `make ir0`. Without `/sbin/init` on `disk.img` the
 kernel **panics** at handoff — there is no in-kernel fallback shell.

--- a/SETUP.md
+++ b/SETUP.md
@@ -14,7 +14,6 @@ For architecture and capability boundaries, see [README.md](README.md).
 | `nasm` | x86-64 assembly |
 | `make` | Build orchestration |
 | `python3` (+ curses) | menuconfig / Kconfig helpers |
-| `rustc` + `cargo` + nightly `rust-src` | Rust drivers in default kernel link |
 | `grub-mkrescue` + `xorriso` | ISO generation (`kernel-x64.iso`) |
 | `qemu-system-x86_64` | Execution |
 
@@ -22,21 +21,26 @@ Debian/Ubuntu example:
 
 ```bash
 sudo apt install build-essential nasm qemu-system-x86 grub-pc-bin xorriso python3
-# Rust (rustup): https://rustup.rs
-rustup toolchain install nightly
-rustup component add rust-src --toolchain nightly
 ```
 
-### Required for static userspace (`PROFILE=userspace`)
+Rust (`rustc` / `cargo` / nightly `rust-src` via [rustup](https://rustup.rs)) is **optional** for the default kernel. It is required only when `.config` has `CONFIG_ENABLE_EXAMPLE_DRIVERS=y` (off in `make defconfig`).
+
+### Required for static userspace / `make first-boot` (`PROFILE=userspace`)
 
 | Tool | Purpose |
 |------|---------|
+| Everything in desktop above | ISO + QEMU |
 | `x86_64-linux-musl-gcc` or `musl-gcc` | Static musl binaries (BusyBox, runit, …) |
+| `git`, `curl`, `patch`, `sha256sum`, `file`, `flock` | Clone sibling, fetch/verify/patch package sources |
+| `yacc` (from `bison`) | Build opendoas (`parse.y`) |
 
 ```bash
-sudo apt install musl-tools
+sudo apt install musl-tools git curl patch file util-linux bison
 # or set MUSL_CC=/path/to/x86_64-linux-musl-gcc
+# Arch: pacman -S musl bison   (musl provides musl-gcc; there is no musl-gcc package)
 ```
+
+`make first-boot` runs `ensure-host-deps` (`IR0_DEPS_INSTALL=ask|yes|never`), creates `.config` via `defconfig` if missing, clones `../IR0-userspace`, builds rootfs + ISO. Optional Doom inject: `IR0_INSTALL_KEN_GAMES=1 REAL_WAD_PATH=/path/to/doom1.wad make first-boot`.
 
 ### Required for ARM hub/watch (`PROFILE=hub` / `watch`)
 
@@ -91,7 +95,7 @@ Product PID1 (runit), BusyBox, login/doas, and `/etc` live in a **separate**
 repository. **Recommended first-time path:**
 
 ```bash
-make first-boot    # checks host deps (asks to install if missing), clones ../IR0-userspace, builds rootfs + ISO
+make first-boot    # deps + defconfig if needed + clone ../IR0-userspace + rootfs + ISO
 make run           # QEMU → BusyBox ash (GTK)
 ```
 

--- a/scripts/bootstrap-userspace.sh
+++ b/scripts/bootstrap-userspace.sh
@@ -36,6 +36,15 @@ echo "  userspace  ${USERSPACE_ROOT}"
 chmod +x "${ROOT}/scripts/ensure-host-deps.sh" "${ROOT}/scripts/deptest.sh"
 PROFILE=userspace "${ROOT}/scripts/ensure-host-deps.sh"
 
+# Product .config — clean clones have none (gitignored). Match SETUP.md.
+if [ ! -f "${ROOT}/.config" ]; then
+	echo "  CONFIG    make defconfig (no .config yet)"
+	make -s defconfig
+fi
+
+# Skip Doom/IWAD inject on the default first-boot path (override with =1).
+export IR0_INSTALL_KEN_GAMES="${IR0_INSTALL_KEN_GAMES:-0}"
+
 if [ ! -f "${USERSPACE_ROOT}/Makefile" ]; then
 	parent="$(dirname "${USERSPACE_ROOT}")"
 	mkdir -p "${parent}"
@@ -70,5 +79,6 @@ Sibling distro ready (runit PID1 + BusyBox, profile=${PROFILE}).
 Next:  make run
 On first boot: create your username + password (used for login and doas).
 Deps:  IR0_DEPS_INSTALL=ask|yes|never (default ask) — see scripts/ensure-host-deps.sh
+Doom:  IR0_INSTALL_KEN_GAMES=1 make first-boot   # optional IWAD via REAL_WAD_PATH
 Docs:  SETUP.md, Documentation/USERSPACE.md
 EOF

--- a/scripts/deptest.sh
+++ b/scripts/deptest.sh
@@ -257,10 +257,28 @@ if command -v python3 >/dev/null 2>&1; then
 	else
 		report_issue "python3-curses" present_but_unusable \
 			"  python3 found but 'import curses' fails (menuconfig TUI)." \
-			"libncurses-dev python3" "python" "python3-libs"
+			"libncurses-dev python3" "python" "python3-curses"
 	fi
 fi
 echo ""
+
+# Prefer rustup's cargo bin when it is not yet on PATH (fresh install / new shell).
+ensure_cargo_path() {
+	if [ -d "${HOME}/.cargo/bin" ]; then
+		case ":${PATH}:" in
+		*":${HOME}/.cargo/bin:"*) ;;
+		*)
+			PATH="${HOME}/.cargo/bin:${PATH}"
+			export PATH
+			;;
+		esac
+	fi
+}
+
+example_drivers_enabled() {
+	[ -f "${KERNEL_ROOT}/.config" ] || return 1
+	_grep -q '^CONFIG_ENABLE_EXAMPLE_DRIVERS=y' "${KERNEL_ROOT}/.config"
+}
 
 # ---------------------------------------------------------------------------
 # Desktop
@@ -316,22 +334,53 @@ need_desktop() {
 		ok_line "xorriso"
 	fi
 
+	# Rust is only linked when CONFIG_ENABLE_EXAMPLE_DRIVERS=y (off in defconfig).
+	if example_drivers_enabled; then
+		need_rust_example_drivers
+	else
+		ensure_cargo_path
+		if command -v rustc >/dev/null 2>&1; then
+			ok_line "rustc (optional): $(rustc --version 2>&1)"
+		else
+			report_issue "rustc" optional \
+				"  Not required for default kernel/ISO (example drivers off). Enable CONFIG_ENABLE_EXAMPLE_DRIVERS=y to link Rust drivers."
+		fi
+	fi
+
+	if [ -f "${KERNEL_ROOT}/.config" ]; then
+		ok_line ".config present"
+	else
+		report_issue ".config" optional \
+			"  Missing — next: make defconfig   (or: make first-boot / make ir0_defconfig PROFILE=desktop)"
+	fi
+	echo ""
+}
+
+# Required only when .config has CONFIG_ENABLE_EXAMPLE_DRIVERS=y.
+need_rust_example_drivers() {
+	echo "Rust example drivers (CONFIG_ENABLE_EXAMPLE_DRIVERS=y):"
+	echo "-------------------------------------------------------"
+	ensure_cargo_path
 	if ! command -v rustc >/dev/null 2>&1; then
 		report_issue "rustc" required \
-			"  Rust drivers are linked into the default kernel image.
+			"  Example Rust drivers are enabled.
   Install: https://rustup.rs
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
     rustup toolchain install nightly
-    rustup component add rust-src --toolchain nightly"
+    rustup component add rust-src --toolchain nightly
+  Then re-open the shell (or: export PATH=\"\$HOME/.cargo/bin:\$PATH\")."
 	else
 		ok_line "rustc: $(rustc --version 2>&1)"
 		if ! command -v cargo >/dev/null 2>&1; then
-			report_issue "cargo" required "  Required with rustc (rustup)."
+			report_issue "cargo" required \
+				"  Required with rustc (rustup). Install: https://rustup.rs"
 		else
 			ok_line "cargo: $(cargo --version 2>&1)"
 		fi
 		if ! command -v rustup >/dev/null 2>&1; then
 			report_issue "rustup" required \
-				"  Required to manage nightly + rust-src for no_std drivers."
+				"  Required to manage nightly + rust-src for no_std drivers.
+  Install: https://rustup.rs"
 		else
 			if rustup toolchain list 2>/dev/null | _grep -q nightly; then
 				ok_line "rustup nightly toolchain"
@@ -347,19 +396,11 @@ need_desktop() {
 			fi
 		fi
 	fi
-
-	if [ -f "${KERNEL_ROOT}/.config" ]; then
-		ok_line ".config present"
-	else
-		report_issue ".config" optional \
-			"  Missing — next: make defconfig   (or: make ir0_defconfig PROFILE=desktop)"
-	fi
-	echo ""
 }
 
 need_userspace() {
-	echo "Userspace musl (required for PROFILE=userspace):"
-	echo "-----------------------------------------------"
+	echo "Userspace musl + fetch tools (required for PROFILE=userspace):"
+	echo "--------------------------------------------------------------"
 	if command -v x86_64-linux-musl-gcc >/dev/null 2>&1; then
 		ok_line "x86_64-linux-musl-gcc: $(x86_64-linux-musl-gcc --version 2>&1 | _head -1)"
 	elif command -v musl-gcc >/dev/null 2>&1; then
@@ -367,7 +408,41 @@ need_userspace() {
 	else
 		report_issue "musl-gcc / x86_64-linux-musl-gcc" required \
 			"  Or set MUSL_CC=/path/to/x86_64-linux-musl-gcc" \
-			"musl-tools" "musl musl-gcc" "musl-gcc"
+			"musl-tools" "musl" "musl-gcc"
+	fi
+	# Clone sibling, download package tarballs, verify, patch, and build probes.
+	require_cmd "git" git "git" "git" "git" --version || true
+	require_cmd "curl" curl "curl" "curl" "curl" --version || true
+	require_cmd "patch" patch "patch" "patch" "patch" --version || true
+	require_cmd "file" file "file" "file" "file" --version || true
+	if command -v sha256sum >/dev/null 2>&1; then
+		ok_line "sha256sum"
+	elif command -v sha256 >/dev/null 2>&1; then
+		ok_line "sha256"
+	else
+		report_issue "sha256sum" required \
+			"  Needed to verify IR0-userspace package tarballs." \
+			"coreutils" "coreutils" "coreutils"
+	fi
+	if command -v flock >/dev/null 2>&1; then
+		ok_line "flock (util-linux)"
+	else
+		report_issue "flock" required \
+			"  Needed by BusyBox package build lock." \
+			"util-linux" "util-linux" "util-linux"
+	fi
+	# opendoas builds parse.c from parse.y via Make's implicit yacc rule.
+	if command -v yacc >/dev/null 2>&1; then
+		ok_line "yacc: $(yacc --version 2>&1 | _head -1 || echo present)"
+	elif command -v bison >/dev/null 2>&1; then
+		# Some installs ship bison without a yacc wrapper; Make still needs `yacc`.
+		report_issue "yacc" required \
+			"  bison found but no 'yacc' on PATH (opendoas parse.y). Install the distro bison package that provides /usr/bin/yacc, or: ln -s \"\$(command -v bison)\" ~/bin/yacc && export PATH=\"\$HOME/bin:\$PATH\"." \
+			"bison" "bison" "bison"
+	else
+		report_issue "yacc" required \
+			"  Needed to build opendoas (parse.y → parse.c)." \
+			"bison" "bison" "bison"
 	fi
 	echo ""
 }

--- a/scripts/ensure-host-deps.sh
+++ b/scripts/ensure-host-deps.sh
@@ -131,8 +131,12 @@ if [ "$fake_fail" -eq 0 ]; then
 fi
 
 if [ ! -s "$LIST" ]; then
-	echo "  deptest failed without a package mapping (version/usability issue)."
-	echo "  Fix the messages above, or see SETUP.md"
+	echo "  Required issue without an installable package mapping (e.g. rustup"
+	echo "  components, wrong toolchain version, or a probe failure)."
+	echo "  Read the [deptest] blocks above and SETUP.md, then fix manually."
+	echo "  Rust example drivers: https://rustup.rs"
+	echo "    rustup toolchain install nightly"
+	echo "    rustup component add rust-src --toolchain nightly"
 	echo "  Then: make deptest PROFILE=${PROFILE}"
 	exit 1
 fi
@@ -200,8 +204,18 @@ if [ "$fake_fail" -eq 1 ]; then
 fi
 
 echo "[ensure-host-deps] Running: ${INSTALL_CMD}"
+set +e
 # shellcheck disable=SC2086
 eval ${INSTALL_CMD}
+install_rc=$?
+set -e
+if [ "$install_rc" -ne 0 ]; then
+	echo "[ensure-host-deps] Package install failed (exit ${install_rc})."
+	echo "  Re-run as a user with sudo, or install manually:"
+	echo "    ${INSTALL_CMD}"
+	echo "  Then: make deptest PROFILE=${PROFILE}"
+	exit 1
+fi
 
 echo ""
 echo "[ensure-host-deps] Re-checking…"

--- a/scripts/inject_ken_games_minix.sh
+++ b/scripts/inject_ken_games_minix.sh
@@ -18,7 +18,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DISK="${1:-${ROOT}/disk.img}"
 INJECT="${ROOT}/scripts/inject_init_minix.py"
 BIN="${IR0_KEN_DOOM_BIN:-${ROOT}/setup/pid1/fase55e_doom_interactive}"
-WAD="${REAL_WAD_PATH:-/home/ivanr013/Escritorio/universal-doom/DOOM1.WAD}"
+WAD="${REAL_WAD_PATH:-}"
 
 if [ "${IR0_INSTALL_KEN_GAMES:-1}" = "0" ]; then
 	echo "  SKIP    ken/games (IR0_INSTALL_KEN_GAMES=0)"
@@ -40,13 +40,13 @@ python3 "${INJECT}" --mode 0755 "${DISK}" "${BIN}" usr/ken/games/doom
 # PATH-visible name (BusyBox which / usr/bin)
 python3 "${INJECT}" --mode 0755 "${DISK}" "${BIN}" usr/bin/doom
 
-if [ -f "${WAD}" ]; then
+if [ -n "${WAD}" ] && [ -f "${WAD}" ]; then
 	echo "  KEN     /usr/ken/games/doom1.wad ← ${WAD}"
 	python3 "${INJECT}" --mode 0644 "${DISK}" "${WAD}" usr/ken/games/doom1.wad
 	# Compat path still used by older smokes
 	python3 "${INJECT}" --mode 0644 "${DISK}" "${WAD}" usr/share/doom/doom1.wad
 else
-	echo "  WARN    ken/games: no IWAD at REAL_WAD_PATH=${WAD}" >&2
+	echo "  WARN    ken/games: no IWAD (set REAL_WAD_PATH=/path/to/doom1.wad)" >&2
 fi
 
 echo "✓ inject_ken_games_minix OK"

--- a/scripts/make/qa.mk
+++ b/scripts/make/qa.mk
@@ -162,7 +162,8 @@ RUNIT_ASH_SMOKE_LOG = /tmp/runit-ash-smoke.log
 DOOM_FRAMES ?= 0
 DOOM_FRAME_DUMP_EVERY ?= 0
 DOOM_DISPLAY ?= gtk
-REAL_WAD_PATH ?= /home/ivanr013/Escritorio/universal-doom/DOOM1.WAD
+# Optional Doom IWAD — set REAL_WAD_PATH=/path/to/doom1.wad for Doom smokes.
+REAL_WAD_PATH ?=
 FASE52_TCC_STAGE = setup/pid1/fase52_staging
 FASE50_PROGRAMS_LOG = /tmp/userspace-fase50-programs.log
 # Serial-log autokill: scripts/smoke_autokill.py (default max 180s; heavy smokes use --profile 90–120s).


### PR DESCRIPTION
## Summary
- Hace `make first-boot` usable en máquinas limpias: Rust nightly solo si `CONFIG_ENABLE_EXAMPLE_DRIVERS=y`.
- Chequea tools de fetch + `yacc`/`bison` (opendoas) y arregla mapping Arch `musl`.
- Auto-`defconfig`, sin ken-games/Doom por defecto, sin path IWAD del mantenedor.

## Test plan
- [ ] En máquina limpia: `make first-boot` (aceptar install de `bison` si falta)
- [ ] `PROFILE=userspace make check-env` pasa con toolchain desktop + musl + bison
- [ ] `make -s arch-guard`
- [ ] Opcional: `IR0_INSTALL_KEN_GAMES=1 REAL_WAD_PATH=/path/doom1.wad make first-boot`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect bootstrap and host-deps gating for all new contributors; Makefile hunks in the diff also drop several `scripts/make/*.mk` includes—verify that is intentional or builds may lose targets.
> 
> **Overview**
> **`make first-boot`** is documented and implemented as a single path on clean clones: **`bootstrap-userspace.sh`** runs **`make defconfig`** when `.config` is missing, defaults **`IR0_INSTALL_KEN_GAMES=0`**, and README/SETUP no longer tell users to run **`defconfig`** separately before first-boot.
> 
> **Host dependency checks** are aligned with that flow: **`deptest.sh`** treats Rust/nightly/`rust-src` as **required only when** `CONFIG_ENABLE_EXAMPLE_DRIVERS=y`, otherwise **optional** (with `~/.cargo/bin` on PATH); **`PROFILE=userspace`** now requires **git, curl, patch, file, sha256, flock, and yacc** for sibling fetch/build (including opendoas), fixes **Arch musl** package mapping and **python3-curses** naming, and **`ensure-host-deps.sh`** surfaces clearer manual-fix guidance and **non-zero exit** if apt install fails.
> 
> **Doom/IWAD** defaults are removed from maintainer paths: **`REAL_WAD_PATH`** is empty in Make/inject scripts unless set; IWAD inject is opt-in via **`REAL_WAD_PATH`** and **`IR0_INSTALL_KEN_GAMES=1`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbde8137ac0bf1580f47833ac69de1fd96af3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->