### PR TITLE
feat(proc): /proc/stat para BusyBox top y bounce ATA

### DIFF
--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -1,12 +1,24 @@
 # IR0 Kernel Changelog
 
-> **Last verified:** 2026-07-25
+> **Last verified:** 2026-07-29
 > **Source of truth:** git history, `make ktm-check`, roadmap smokes in `Makefile`, [`HARDENING.md`](HARDENING.md), [`KTM.md`](KTM.md)
 
 This file tracks user-visible and developer-facing changes per iteration.
 For tier backlog see [`ROADMAP.md`](ROADMAP.md). For **what is stable in QEMU** see [`STABLE.md`](STABLE.md).
 
 ## [Unreleased]
+
+### `/proc/stat` + BusyBox `top` + ATA odd-buffer bounce (2026-07-29)
+
+- `/proc/stat` (`proc_stat_read`): Linux-shaped `cpu`/`cpu0` jiffy lines so
+  BusyBox `top` can open `/proc/stat` after `chdir("/proc")`.
+- `proc_readdir("/proc")` lists digit PID dirs **before** static registry names
+  so `GETDENTS_BATCH_MAX` (24) does not hide all processes from `top`/`ps`.
+- ATA/MINIX: bounce path for odd userspace buffers; gate MINIX fast-path when
+  dst/src is odd (stops `ATA_BUFFER_ALIGNMENT_SUSPECT` storms).
+- Smokes: `scripts/smoke_proc_stat_top.py`; `smoke_proc_coherence.py` checks
+  `/proc/stat`. Docs: [`VIRTUAL_FILESYSTEMS.md`](VIRTUAL_FILESYSTEMS.md),
+  [`PROCESSES.md`](PROCESSES.md) (reparent-to-init note).
 
 ### Doom T2 audio/mouse + ESC + TinyCC `/lib/tcc` (2026-07-28)
 

--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -16,6 +16,9 @@ For tier backlog see [`ROADMAP.md`](ROADMAP.md). For **what is stable in QEMU** 
   so `GETDENTS_BATCH_MAX` (24) does not hide all processes from `top`/`ps`.
 - ATA/MINIX: bounce path for odd userspace buffers; gate MINIX fast-path when
   dst/src is odd (stops `ATA_BUFFER_ALIGNMENT_SUSPECT` storms).
+- MINIX `--format-large`: wipe inode table + rebuild imap (stale inodes from a
+  prior pack broke `/etc` inject → `ROOTFS_VERIFY_FAIL … missing component 'etc'`);
+  large images use 2048 inodes.
 - Smokes: `scripts/smoke_proc_stat_top.py`; `smoke_proc_coherence.py` checks
   `/proc/stat`. Docs: [`VIRTUAL_FILESYSTEMS.md`](VIRTUAL_FILESYSTEMS.md),
   [`PROCESSES.md`](PROCESSES.md) (reparent-to-init note).

--- a/Documentation/DRIVERS.md
+++ b/Documentation/DRIVERS.md
@@ -13,7 +13,9 @@ IR0 uses a centralized registry and bootstrap path for core and optional drivers
 
 - Input: PS/2 controller, keyboard, mouse.
 - Timers: PIT, RTC, HPET, LAPIC, clock abstraction.
-- Storage: ATA core and ATA block path.
+- Storage: ATA core and ATA block path. Odd userspace buffers use a 512-byte
+  bounce in `drivers/storage/ata.c`; MINIX fast-path skips when dst/src is odd
+  (`fs/minix_fs.c`) to avoid alignment storms.
 - Network: RTL8139 path used by network stack.
 - Audio: Sound Blaster, Adlib, PC speaker.
 - Video/console: typewriter, console backend, VBE path.

--- a/Documentation/PROCESSES.md
+++ b/Documentation/PROCESSES.md
@@ -1,12 +1,16 @@
 # IR0 Process Model
 
+> **Last verified:** 2026-07-29
+> **Source of truth:** `kernel/process/exit.c`, `kernel/process/wait.c`,
+> `kernel/syscalls/process_syscalls.c`, [`releases/PROCESS_LIFECYCLE_SPEC.md`](releases/PROCESS_LIFECYCLE_SPEC.md)
+
 IR0 process handling centers on practical lifecycle management plus incremental
 Unix credential semantics.
 
 ## Core Areas
 
-- Lifecycle and tables in `kernel/process.c` and `kernel/process.h`.
-- Syscall integration in `kernel/syscalls.c`.
+- Lifecycle split under `kernel/process/` (`exit.c`, `wait.c`, fork/create, …).
+- Syscall integration in `kernel/syscalls/process_syscalls.c` (and related).
 - Scheduler handoff through scheduler API.
 - Signal and wait/reap paths integrated with process state transitions.
 
@@ -17,6 +21,20 @@ Unix credential semantics.
 - File descriptor table and working directory.
 - Credentials: `uid/gid/euid/egid` and `umask`.
 - Pending signal state and termination metadata.
+
+## Exit, reparent, wait
+
+On `process_exit()` (`kernel/process/exit.c`):
+
+1. Reap the dying task’s own zombie children (`process_reap_zombies`).
+2. **`process_reparent_children`** — every live child with `ppid == dying->pid`
+   gets **`ppid = 1`** (init), Linux/Unix orphan adoption.
+3. Mark the dying task `PROCESS_ZOMBIE` until its parent (or init) `wait`s it.
+4. Notify parent (`SIGCHLD` / wait wake) then schedule away.
+
+Edge case: if PID 1 is missing or the dying task *is* init, orphans are detached
+with **`ppid = 0`** (no alternate subreaper). ISD/runit does not implement
+userspace adoption; it relies on this kernel path.
 
 ## Current Credential Semantics
 
@@ -30,6 +48,7 @@ Unix credential semantics.
 ## Strengths
 
 - Clear process lifecycle with explicit wait/reap handling.
+- Orphan reparent to init matches classical Unix expectations.
 - Credential fields are now actively used in policy decisions.
 - Better alignment with Unix-like ownership and permission flow.
 
@@ -38,4 +57,4 @@ Unix credential semantics.
 - Full account/session model remains intentionally lightweight.
 - Some advanced fork/exec/credential edge cases are still maturing.
 - Thread-level model is not a primary focus yet.
-
+- PID 1 must `wait` reparented zombies; runit is not a full systemd-style reaper.

--- a/Documentation/USERSPACE.md
+++ b/Documentation/USERSPACE.md
@@ -1,6 +1,6 @@
 # Coupling IR0 (kernel) ↔ ISD
 
-> **Last verified:** 2026-07-28  
+> **Last verified:** 2026-07-29  
 > **Source of truth:** this file, `scripts/make/isd.mk`, `scripts/bootstrap-isd.sh`, sibling [ISD](https://github.com/IRodriguez13/ISD), [SETUP.md](../SETUP.md).  
 > **Spanish:** [`esp/USERSPACE.md`](esp/USERSPACE.md)
 
@@ -23,12 +23,21 @@ canonical product path. Legacy `load-userspace-runit` remains for smokes
 
 ## Fastest path (first time)
 
+Happy path on an **x86_64 Linux** host (Debian/Ubuntu/Arch/Fedora/openSUSE or
+WSL2). Target: clone → two commands → QEMU with ash.
+
 ```bash
 git clone https://github.com/IRodriguez13/IR0.git
 cd IR0
 make first-boot PROFILE=minimal
 make run PROFILE=minimal
 ```
+
+| PROFILE | Expectation in guest |
+|---------|----------------------|
+| `minimal` | Interactive firstboot (create user) then login |
+| `development` | Lab autologin root (empty password allowed) |
+| `desktop` | Like minimal + fuller BusyBox/applets (heavier pack) |
 
 `first-boot` will:
 
@@ -37,8 +46,11 @@ make run PROFILE=minimal
 3. Clone `../ISD` if missing
 4. Write `.isdconfig` only if absent
 5. Fetch sources, export UAPI, build packages (stamp-incremental)
-6. Stage rootfs + pack `disk.img` under ISD
+6. Stage rootfs + pack `disk.img` under ISD (`format-large` wipes MINIX inodes)
 7. Build `kernel-x64-userspace.iso`
+
+`make run` rebuilds the ISO if needed, then `ensure-isd-disk` (stamp-incremental
+pack; first pack ~1–3 min — progress is printed). Then QEMU GTK.
 
 Layout:
 
@@ -73,7 +85,8 @@ parent/
 | `make first-boot PROFILE=…` | Full product bootstrap |
 | `make isdconfig PROFILE=…` | Interactive extras (TTY: packages + applets e.g. top) |
 | `make isd` / `isd-rootfs` / `isd-image` | Delegate to ISD |
-| `make run PROFILE=…` | Boot ISD disk (no rebuild if up to date) |
+| `make run PROFILE=…` | Boot ISD disk (stamp-incremental pack) |
+| `make run-console PROFILE=…` | Same without GTK |
 | `make bootstrap-userspace` | **Deprecated** → `first-boot` |
 | `IR0_LEGACY_USERSPACE=1 make run` | Old inject path (smokes) |
 

--- a/Documentation/VIRTUAL_FILESYSTEMS.md
+++ b/Documentation/VIRTUAL_FILESYSTEMS.md
@@ -1,6 +1,6 @@
 # IR0 Virtual Filesystems
 
-> **Last verified:** 2026-07-24
+> **Last verified:** 2026-07-29
 > **Source of truth:** `fs/procfs.c`, `fs/sysfs.c`, `fs/devfs.c`, `fs/heartfs.c`,
 > `fs/pseudo_fs_registry.c`, [`PSEUDO_FS_HEART.md`](PSEUDO_FS_HEART.md),
 > [`KLOG.md`](KLOG.md) (`/proc/kmsg`, `/dev/kmsg`)
@@ -20,6 +20,8 @@ See [`PSEUDO_FS_HEART.md`](PSEUDO_FS_HEART.md) for layout, gates, and ARCH-3 not
 
 - `/proc/meminfo`
 - `/proc/uptime`
+- `/proc/stat` — aggregate + `cpu0` jiffy lines for BusyBox `top` (see below)
+- `/proc/loadavg`
 - `/proc/version`
 - `/proc/filesystems`
 - `/proc/mounts`
@@ -30,6 +32,32 @@ See [`PSEUDO_FS_HEART.md`](PSEUDO_FS_HEART.md) for layout, gates, and ARCH-3 not
 - `/proc/kmsg` — structured klog records (`klog_read_records`, see [`KLOG.md`](KLOG.md))
 - `/proc/[pid]/status`
 - `/proc/[pid]/cmdline`
+- `/proc/[pid]/stat` — Linux `proc(5)` field order (CPU counters still mostly 0)
+
+### `/proc/stat` (BusyBox `top`)
+
+Registered via `pseudo_fs_register("/proc", "stat", …)` → `proc_stat_read()`.
+
+Contract (Linux `proc_stat(5)` / BusyBox `read_cpu_jiffy`):
+
+```text
+cpu  user nice system idle iowait irq softirq steal
+cpu0 user nice system idle iowait irq softirq steal
+…
+```
+
+- Jiffies use `CONFIG_TICK_RATE_HZ`; idle from `clock_get_idle_milliseconds()`.
+- Non-idle time is split user/system heuristically (no per-process cputime yet).
+- Guest check: `python3 scripts/smoke_proc_stat_top.py` (ISD development disk +
+  `top -bn1`).
+
+### `/proc` readdir and `getdents`
+
+`proc_readdir("/proc")` lists **numeric PID directories first**, then `pid/`, then
+static registry children. Reason: `sys_getdents` uses `GETDENTS_BATCH_MAX` (24)
+on a stack-sized `vfs_dirent` array; filling the batch with static names alone
+left BusyBox `top`/`ps` with **no** digit dirents → `no process info in /proc`.
+Static files remain openable by path even when truncated from a directory listing.
 
 ### Notes
 
@@ -77,8 +105,11 @@ See [`PSEUDO_FS_HEART.md`](PSEUDO_FS_HEART.md) for layout, gates, and ARCH-3 not
 - Strong observability at runtime without external debug tooling.
 - Consistent user-facing access model through open/read/write/stat patterns.
 - Product exploration: ash + `cat /proc/kmsg` (in-kernel dbgshell removed).
+- BusyBox `top -bn1` works once `/proc/stat` + digit `/proc` dirents are present.
 
 ## Weak Points
 
 - Some endpoints remain intentionally minimal and need richer semantics.
 - Coverage of edge-case parsing/format compatibility still depends on runtime tests.
+- `getdents` batch size still caps how many `/proc` names a single listing returns.
+- `/proc/stat` CPU breakdown is approximate until real per-task accounting exists.

--- a/Documentation/esp/PROCESSES.md
+++ b/Documentation/esp/PROCESSES.md
@@ -1,40 +1,57 @@
 # Modelo de Procesos en IR0
 
-El manejo de procesos en IR0 prioriza ciclo de vida claro y semantica Unix de
+> **Última verificación:** 2026-07-29
+> **Fuente de verdad:** `kernel/process/exit.c`, `kernel/process/wait.c`,
+> [`PROCESSES.md`](../PROCESSES.md) (canónico en inglés)
+
+El manejo de procesos en IR0 prioriza ciclo de vida claro y semántica Unix de
 credenciales en forma incremental.
 
-## Areas Core
+## Áreas core
 
-- Ciclo de vida y tablas en `kernel/process.c` y `kernel/process.h`.
-- Integracion con syscalls en `kernel/syscalls.c`.
-- Handoff al scheduler via scheduler API.
-- Rutas de senales y wait/reap integradas al estado de proceso.
+- Ciclo de vida bajo `kernel/process/` (`exit.c`, `wait.c`, fork/create, …).
+- Integración con syscalls en `kernel/syscalls/process_syscalls.c`.
+- Handoff al scheduler vía scheduler API.
+- Rutas de señales y wait/reap integradas al estado de proceso.
 
-## Datos Clave por Proceso
+## Datos clave por proceso
 
 - PID/PPID y enlaces de lista de procesos.
 - Metadatos de contexto/tarea y address-space.
 - Tabla de file descriptors y directorio de trabajo.
 - Credenciales: `uid/gid/euid/egid` y `umask`.
-- Estado de senales pendientes y metadata de salida.
+- Estado de señales pendientes y metadata de salida.
 
-## Semantica Actual de Credenciales
+## Exit, reparent, wait
+
+En `process_exit()`:
+
+1. Reap de zombies propios.
+2. **`process_reparent_children`** → hijos con `ppid` del moribundo pasan a
+   **`ppid = 1`** (init).
+3. El moribundo queda zombie hasta `wait` del padre (o de init).
+4. Si no hay init (o muere el propio PID 1): huérfanos con **`ppid = 0`**.
+
+ISD no reparenta en userspace; depende del kernel.
+
+## Semántica actual de credenciales
 
 - Los checks de permisos usan credenciales efectivas.
 - Superficie de syscalls de identidad:
   - `getuid/geteuid/getgid/getegid`
   - `setuid/setgid`
   - `umask`
-- Existe un modelo minimo de usuarios para separacion root/user.
+- Existe un modelo mínimo de usuarios para separación root/user.
 
-## Puntos Fuertes
+## Puntos fuertes
 
-- Ciclo de vida explicito con wait/reap bien definido.
-- Las credenciales ya participan en decisiones de politica reales.
-- Mejor alineacion con ownership y permisos tipo Unix.
+- Ciclo de vida explícito con wait/reap bien definido.
+- Reparent de huérfanos a init al estilo Unix clásico.
+- Las credenciales ya participan en decisiones de política reales.
 
-## Puntos Debiles
+## Puntos débiles
 
-- El modelo completo de cuentas/sesion sigue siendo liviano.
-- Algunos casos borde de fork/exec/credenciales aun maduran.
+- El modelo completo de cuentas/sesión sigue siendo liviano.
+- Algunos casos borde de fork/exec/credenciales aún maduran.
 - El modelo de threads no es foco principal por ahora.
+- PID 1 debe hacer `wait` de zombies reparentados.

--- a/Documentation/esp/USERSPACE.md
+++ b/Documentation/esp/USERSPACE.md
@@ -1,6 +1,6 @@
 # Acoplamiento IR0 (kernel) ↔ ISD
 
-> **Última verificación:** 2026-07-28  
+> **Última verificación:** 2026-07-29  
 > **Fuente de verdad:** este archivo, `scripts/make/isd.mk`, hermano [ISD](https://github.com/IRodriguez13/ISD), [SETUP.md](../../SETUP.md).  
 > **English:** [`../USERSPACE.md`](../USERSPACE.md)
 
@@ -10,6 +10,10 @@ El kernel no es una distro. PID1 (**runit**), **BusyBox**, paquetes, rootfs y
 `disk.img` viven en **ISD**. IR0 compila el kernel, exporta UAPI, delega la
 build de ISD y arranca la imagen.
 
+## Camino feliz (primera vez)
+
+Host **x86_64 Linux** (o WSL2). Objetivo: clonar → dos comandos → QEMU.
+
 ```bash
 git clone https://github.com/IRodriguez13/IR0.git
 cd IR0
@@ -17,8 +21,15 @@ make first-boot PROFILE=minimal
 make run PROFILE=minimal
 ```
 
+| PROFILE | En el guest |
+|---------|-------------|
+| `minimal` | Firstboot interactivo (crear usuario) + login |
+| `development` | Autologin root (lab) |
+| `desktop` | Como minimal + más applets (pack más lento) |
+
 `first-boot` pregunta antes de instalar deps del host (`IR0_DEPS_INSTALL=ask|yes|never`).
-Clona `../ISD` si falta. No inyecta binarios uno a uno.
+Clona `../ISD` si falta. `make run` puede tardar 1–3 min en el primer pack
+MINIX (imprime progreso); no está colgado tras el ISO.
 
 | Variable | Default |
 |----------|---------|
@@ -32,6 +43,7 @@ Clona `../ISD` si falta. No inyecta binarios uno a uno.
 | `make isdconfig PROFILE=…` | Extras interactivos (paquetes + applets, p. ej. top) |
 | `make isd-image PROFILE=…` | Solo imagen ISD |
 | `make run PROFILE=…` | QEMU con disco ISD |
+| `make run-console PROFILE=…` | Sin GTK |
 | `bootstrap-userspace` | Deprecado → `first-boot` |
 
 Config: `IR0/.config` (kernel) ≠ `ISD/.isdconfig` (extras de distro).

--- a/Documentation/esp/VIRTUAL_FILESYSTEMS.md
+++ b/Documentation/esp/VIRTUAL_FILESYSTEMS.md
@@ -1,5 +1,9 @@
 # Virtual Filesystems en IR0
 
+> **Última verificación:** 2026-07-29
+> **Fuente de verdad:** `fs/procfs.c`, `fs/sysfs.c`, `fs/devfs.c`, `fs/heartfs.h`,
+> [`VIRTUAL_FILESYSTEMS.md`](../VIRTUAL_FILESYSTEMS.md) (canónico en inglés)
+
 Este documento se enfoca en pseudo-filesystems expuestos por VFS.
 
 ## `/proc`
@@ -10,6 +14,8 @@ Este documento se enfoca en pseudo-filesystems expuestos por VFS.
 
 - `/proc/meminfo`
 - `/proc/uptime`
+- `/proc/stat` — líneas `cpu`/`cpu0` (jiffies) para BusyBox `top`
+- `/proc/loadavg`
 - `/proc/version`
 - `/proc/filesystems`
 - `/proc/mounts`
@@ -19,11 +25,24 @@ Este documento se enfoca en pseudo-filesystems expuestos por VFS.
 - `/proc/partitions`
 - `/proc/[pid]/status`
 - `/proc/[pid]/cmdline`
+- `/proc/[pid]/stat`
+
+### `/proc/stat` y BusyBox `top`
+
+- Registro: `proc_stat_read()` en `fs/procfs.c`.
+- Formato Linux: `cpu` + `cpu0` con ≥4 campos tras la etiqueta (user nice system idle …).
+- Smoke: `python3 scripts/smoke_proc_stat_top.py`.
+
+### Readdir de `/proc`
+
+Los dirents numéricos (PID) van **antes** que el registry estático porque
+`GETDENTS_BATCH_MAX` es 24; si solo caben nombres estáticos, `top`/`ps` ven
+`no process info in /proc`.
 
 ### Notas
 
 - Los datos se generan al momento de leer.
-- Se endurecio el formateo numerico para valores de 64 bits.
+- Se endureció el formateo numérico para valores de 64 bits.
 - El tracking de contexto por proceso evita colisiones entre procesos.
 
 ## `/dev`
@@ -42,29 +61,31 @@ Este documento se enfoca en pseudo-filesystems expuestos por VFS.
 
 ### Notas
 
-- El acceso usa I/O por syscall desde binarios estilo userspace.
-- El registro de dispositivos pasa por bootstrap/registry de drivers.
+- El acceso usa I/O estándar por syscalls desde binarios user-style.
+- El registro de dispositivos pasa por infraestructura de drivers/bootstrap.
 
 ## `/sys`
 
-`sysfs` expone informacion estructurada de kernel/sistema.
+`sysfs` expone datos de kernel/sistema en un namespace estructurado.
 
 ### Notas
 
-- Los paths de error retornan `errno` negativo de forma consistente.
-- La exposicion de consola/backend pasa por interfaces facade.
+- Los paths de error usan retornos errno negativos consistentes.
+- Consola y backends se exponen vía facades.
 
-## Backends Pseudo en Memoria
+## Backends pseudo en memoria
 
-- `tmpfs`: arbol writable en RAM con uid/gid y umask en create.
-- `procfs`, `devfs`, `sysfs`: pseudo-filesystems dinamicos.
+- `tmpfs`: árbol escribible en RAM con uid/gid y create consciente de umask.
+- `procfs`, `devfs`, `sysfs`: filesystems pseudo dinámicos.
 
-## Puntos Fuertes
+## Puntos fuertes
 
-- Alta observabilidad runtime sin herramientas externas.
-- Modelo uniforme para open/read/write/stat.
+- Observabilidad runtime sin tooling externo.
+- Modelo de acceso abierto/lectura/escritura/stat coherente.
+- `top -bn1` usable con `/proc/stat` + PIDs en readdir.
 
-## Puntos Debiles
+## Puntos débiles
 
-- Algunos endpoints son intencionalmente minimos y deben crecer.
-- La cobertura de casos borde depende todavia de pruebas runtime.
+- Algunos endpoints siguen mínimos a propósito.
+- El batch de `getdents` sigue truncando listados grandes de `/proc`.
+- El desglose CPU de `/proc/stat` es heurístico hasta haber cputime por tarea.

--- a/SETUP.md
+++ b/SETUP.md
@@ -40,7 +40,7 @@ sudo apt install musl-tools git curl patch file util-linux bison
 # Arch: pacman -S musl bison   (musl provides musl-gcc; there is no musl-gcc package)
 ```
 
-`make first-boot` runs `ensure-host-deps` (`IR0_DEPS_INSTALL=ask|yes|never`), creates `.config` via `defconfig` if missing, clones `../IR0-userspace`, builds rootfs + ISO. Optional Doom inject: `IR0_INSTALL_KEN_GAMES=1 REAL_WAD_PATH=/path/to/doom1.wad make first-boot`.
+`make first-boot` runs `ensure-host-deps` (`IR0_DEPS_INSTALL=ask|yes|never`), creates `.config` via `defconfig` if missing, clones sibling **ISD**, builds rootfs + ISO. Optional Doom inject: `IR0_INSTALL_KEN_GAMES=1 REAL_WAD_PATH=/path/to/doom1.wad make first-boot`.
 
 ### Required for ARM hub/watch (`PROFILE=hub` / `watch`)
 
@@ -155,10 +155,10 @@ This installs `setup/defconfig` as `.config` and regenerates `config.h`.
 Default highlights:
 
 - x86-64, MINIX root on `hda`, round-robin scheduler
-- runit `/sbin/init` from sibling **IR0-userspace** (no in-kernel dbgshell)
+- runit `/sbin/init` from sibling **ISD** (no in-kernel dbgshell)
 - VBE framebuffer enabled (`CONFIG_ENABLE_VBE=y`)
 
-Daily run targets build the userspace ISO and inject the runit rootfs.
+Daily run targets build the userspace ISO and use the ISD-owned `disk.img`.
 Clone layout and wiring: [`Documentation/USERSPACE.md`](Documentation/USERSPACE.md).
 
 ## Basic Kernel Build

--- a/drivers/storage/ata.c
+++ b/drivers/storage/ata.c
@@ -61,6 +61,7 @@ typedef enum
 
 static int ata_single_sector_announced;
 static int ata_multi_sector_warned;
+static int ata_buffer_align_warned;
 
 static int ata_trace_on(void)
 {
@@ -676,9 +677,10 @@ static bool ata_read_one_sector_pio(uint8_t drive, uint32_t lba, void *buffer,
 	return false;
 }
 
-bool ata_read_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors, void* buffer)
+bool ata_read_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors, void *buffer)
 {
 	uint8_t s;
+	int need_bounce;
 
 	if (!ata_drives_present[drive] || !buffer || num_sectors == 0)
 		return false;
@@ -689,8 +691,12 @@ bool ata_read_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors, void* bu
 		ata_emit_classify("ATA_SINGLE_SECTOR_MODE_FIXED");
 	}
 
-	if (((uintptr_t)buffer & 0x1U) != 0U)
+	need_bounce = (((uintptr_t)buffer & 0x1U) != 0U);
+	if (need_bounce && !ata_buffer_align_warned)
+	{
+		ata_buffer_align_warned = 1;
 		ata_emit_classify("ATA_BUFFER_ALIGNMENT_SUSPECT");
+	}
 
 	if (num_sectors > 1 && !ata_multi_sector_warned)
 	{
@@ -703,73 +709,138 @@ bool ata_read_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors, void* bu
 		uint32_t sector_lba = lba + (uint32_t)s;
 		uint8_t *dest = (uint8_t *)buffer + (size_t)s * ATA_SECTOR_SIZE;
 
-		if (!ata_read_one_sector_pio(drive, sector_lba, dest, s, 1))
+		if (need_bounce)
+		{
+			uint8_t bounce[ATA_SECTOR_SIZE] __attribute__((aligned(2)));
+
+			if (!ata_read_one_sector_pio(drive, sector_lba, bounce, s, 1))
+				return false;
+			memcpy(dest, bounce, ATA_SECTOR_SIZE);
+		}
+		else if (!ata_read_one_sector_pio(drive, sector_lba, dest, s, 1))
+		{
 			return false;
+		}
 	}
 
 	return true;
 }
 
-bool ata_write_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors, const void* buffer) 
+static bool ata_write_one_sector_pio(uint8_t drive, uint32_t lba, const void *buffer)
 {
-    
-    if (!ata_drives_present[drive]) 
-    {
-        return false;
-    }
-    
-    uint16_t status_port = ata_get_status_port(drive);
-    (void)status_port; // Variable not used in this implementation
-    uint16_t drive_head_port = ata_get_drive_head_port(drive);
-    uint16_t sector_count_port = ata_get_sector_count_port(drive);
-    uint16_t lba_low_port = ata_get_lba_low_port(drive);
-    uint16_t lba_mid_port = ata_get_lba_mid_port(drive);
-    uint16_t lba_high_port = ata_get_lba_high_port(drive);
-    uint16_t command_port = ata_get_command_port(drive);
-    uint16_t data_port = ata_get_port_base(drive);
-    
-    // Select drive
-    uint8_t drive_select = (drive % 2 == 0) ? ATA_DRIVE_MASTER : ATA_DRIVE_SLAVE;
-    outb(drive_head_port, drive_select | 0x40); // LBA mode
-    
-    // Wait for drive to be ready
-    if (!ata_wait_ready(drive)) 
-    {
-        return false;
-    }
-    
-    // Set up LBA address
-    outb(sector_count_port, num_sectors);
-    outb(lba_low_port, lba & 0xFF);
-    outb(lba_mid_port, (lba >> 8) & 0xFF);
-    outb(lba_high_port, (lba >> 16) & 0xFF);
-    outb(drive_head_port, drive_select | 0x40 | ((lba >> 24) & 0x0F));
-    
-    // Send write command
-    outb(command_port, ATA_CMD_WRITE_SECTORS);
-    
-    // Write data
-    const uint16_t* buffer16 = (const uint16_t*)buffer;
-    for (int sector = 0; sector < num_sectors; sector++) 
-    {
-        // Wait for DRQ
-        if (!ata_wait_drq(drive)) 
-        {
-            return false;
-        }
-        
-        // Write sector
-        for (int i = 0; i < 256; i++) 
-        {
-            outw(data_port, buffer16[sector * 256 + i]);
-        }
-    }
+	uint16_t drive_head_port = ata_get_drive_head_port(drive);
+	uint16_t sector_count_port = ata_get_sector_count_port(drive);
+	uint16_t lba_low_port = ata_get_lba_low_port(drive);
+	uint16_t lba_mid_port = ata_get_lba_mid_port(drive);
+	uint16_t lba_high_port = ata_get_lba_high_port(drive);
+	uint16_t command_port = ata_get_command_port(drive);
+	uint16_t data_port = ata_get_port_base(drive);
+	uint8_t drive_select = (drive % 2 == 0) ? ATA_DRIVE_MASTER : ATA_DRIVE_SLAVE;
+	const uint16_t *buffer16 = (const uint16_t *)buffer;
+	int i;
 
-    /*
-     * Do not FLUSH_CACHE after every PIO write — that serializes bulk
-     * MINIX zone growth (FASE52D ~500KB) into multi-minute hangs.
-     * Callers that need durability should use ir0_block_flush / fsync.
-     */
-    return ata_wait_ready(drive);
+	outb(drive_head_port, drive_select | 0x40);
+	if (!ata_wait_ready(drive))
+		return false;
+
+	outb(sector_count_port, 1);
+	outb(lba_low_port, lba & 0xFF);
+	outb(lba_mid_port, (lba >> 8) & 0xFF);
+	outb(lba_high_port, (lba >> 16) & 0xFF);
+	outb(drive_head_port, drive_select | 0x40 | ((lba >> 24) & 0x0F));
+	outb(command_port, ATA_CMD_WRITE_SECTORS);
+
+	if (!ata_wait_drq(drive))
+		return false;
+
+	for (i = 0; i < 256; i++)
+		outw(data_port, buffer16[i]);
+
+	return ata_wait_ready(drive);
+}
+
+bool ata_write_sectors(uint8_t drive, uint32_t lba, uint8_t num_sectors,
+		       const void *buffer)
+{
+	uint8_t s;
+	int need_bounce;
+
+	if (!ata_drives_present[drive] || !buffer || num_sectors == 0)
+		return false;
+
+	need_bounce = (((uintptr_t)buffer & 0x1U) != 0U);
+	if (need_bounce && !ata_buffer_align_warned)
+	{
+		ata_buffer_align_warned = 1;
+		ata_emit_classify("ATA_BUFFER_ALIGNMENT_SUSPECT");
+	}
+
+	if (num_sectors > 1 && !ata_multi_sector_warned)
+	{
+		ata_multi_sector_warned = 1;
+		ata_emit_classify("ATA_MULTI_SECTOR_UNSAFE");
+	}
+
+	/*
+	 * Odd caller buffers: PIO one sector through an aligned bounce.
+	 * Aligned multi-sector keeps the historical single-command path.
+	 */
+	if (need_bounce)
+	{
+		for (s = 0; s < num_sectors; s++)
+		{
+			uint8_t bounce[ATA_SECTOR_SIZE] __attribute__((aligned(2)));
+			const uint8_t *src =
+				(const uint8_t *)buffer + (size_t)s * ATA_SECTOR_SIZE;
+
+			memcpy(bounce, src, ATA_SECTOR_SIZE);
+			if (!ata_write_one_sector_pio(drive, lba + (uint32_t)s, bounce))
+				return false;
+		}
+		return true;
+	}
+
+	{
+		uint16_t drive_head_port = ata_get_drive_head_port(drive);
+		uint16_t sector_count_port = ata_get_sector_count_port(drive);
+		uint16_t lba_low_port = ata_get_lba_low_port(drive);
+		uint16_t lba_mid_port = ata_get_lba_mid_port(drive);
+		uint16_t lba_high_port = ata_get_lba_high_port(drive);
+		uint16_t command_port = ata_get_command_port(drive);
+		uint16_t data_port = ata_get_port_base(drive);
+		uint8_t drive_select =
+			(drive % 2 == 0) ? ATA_DRIVE_MASTER : ATA_DRIVE_SLAVE;
+		const uint16_t *buffer16 = (const uint16_t *)buffer;
+		int sector;
+
+		outb(drive_head_port, drive_select | 0x40);
+		if (!ata_wait_ready(drive))
+			return false;
+
+		outb(sector_count_port, num_sectors);
+		outb(lba_low_port, lba & 0xFF);
+		outb(lba_mid_port, (lba >> 8) & 0xFF);
+		outb(lba_high_port, (lba >> 16) & 0xFF);
+		outb(drive_head_port, drive_select | 0x40 | ((lba >> 24) & 0x0F));
+		outb(command_port, ATA_CMD_WRITE_SECTORS);
+
+		for (sector = 0; sector < num_sectors; sector++)
+		{
+			int i;
+
+			if (!ata_wait_drq(drive))
+				return false;
+
+			for (i = 0; i < 256; i++)
+				outw(data_port, buffer16[sector * 256 + i]);
+		}
+
+		/*
+		 * Do not FLUSH_CACHE after every PIO write — that serializes bulk
+		 * MINIX zone growth (FASE52D ~500KB) into multi-minute hangs.
+		 * Callers that need durability should use ir0_block_flush / fsync.
+		 */
+		return ata_wait_ready(drive);
+	}
 }
 

--- a/fs/minix_fs.c
+++ b/fs/minix_fs.c
@@ -2250,7 +2250,8 @@ static int minix_fs_pread_at(const char *path, void *buf, size_t count,
     {
       kmemset(dst, 0, chunk);
     }
-    else if (block_off == 0 && chunk == MINIX_BLOCK_SIZE)
+    else if (block_off == 0 && chunk == MINIX_BLOCK_SIZE &&
+             ((uintptr_t)dst & 1U) == 0U)
     {
       if (minix_read_block(disk_zone, dst) != 0)
         return -EIO;
@@ -2353,7 +2354,8 @@ static int minix_fs_pwrite_at(const char *path, const void *buf, size_t count,
     if (ret != 0)
       return ret;
 
-    if (block_off == 0 && chunk == MINIX_BLOCK_SIZE)
+    if (block_off == 0 && chunk == MINIX_BLOCK_SIZE &&
+        ((uintptr_t)src & 1U) == 0U)
     {
       if (minix_write_block(disk_zone, src) != 0)
         return -EIO;

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -536,6 +536,86 @@ int proc_uptime_read(char *buf, size_t count)
 	return len;
 }
 
+/*
+ * /proc/stat — Linux proc(5) / BusyBox top contract.
+ *
+ * Aggregate "cpu" + single "cpu0" jiffy lines (USER_HZ ≈ CONFIG_TICK_RATE_HZ).
+ * IR0 has no per-state CPU accounting yet: idle from clock_get_idle_milliseconds(),
+ * non-idle split user/system; nice/iowait/irq/softirq/steal are 0.
+ * Source: man7.org/linux/man-pages/man5/proc_stat.5.html
+ */
+int proc_stat_read(char *buf, size_t count)
+{
+	uint64_t total;
+	uint64_t idle;
+	uint64_t busy;
+	uint64_t user;
+	uint64_t system;
+	uint64_t nice = 0;
+	uint64_t iowait = 0;
+	uint64_t irq = 0;
+	uint64_t softirq = 0;
+	uint64_t steal = 0;
+	unsigned runnable = 0;
+	unsigned nprocs = 0;
+	int len;
+
+	if (VALIDATE_BUFFER(buf, count) != 0)
+		return -1;
+	memset(buf, 0, count);
+
+	total = clock_get_tick_count();
+	idle = clock_get_idle_milliseconds() * (uint64_t)CONFIG_TICK_RATE_HZ / 1000ULL;
+	if (idle > total)
+		idle = total;
+	busy = total - idle;
+	user = busy / 2ULL;
+	system = busy - user;
+
+	clock_get_loadavg(NULL, NULL, NULL, &runnable, &nprocs, NULL);
+
+	/*
+	 * Eight fields after the label so FEATURE_TOP_SMP_CPU (BusyBox) accepts
+	 * both the aggregate line (>=4) and cpu0 (>4). Duplicate cpu0: one logical CPU.
+	 */
+	len = snprintf(buf, count,
+		       "cpu  %llu %llu %llu %llu %llu %llu %llu %llu\n"
+		       "cpu0 %llu %llu %llu %llu %llu %llu %llu %llu\n"
+		       "intr 0\n"
+		       "ctxt 0\n"
+		       "btime 0\n"
+		       "processes %u\n"
+		       "procs_running %u\n"
+		       "procs_blocked 0\n",
+		       (unsigned long long)user,
+		       (unsigned long long)nice,
+		       (unsigned long long)system,
+		       (unsigned long long)idle,
+		       (unsigned long long)iowait,
+		       (unsigned long long)irq,
+		       (unsigned long long)softirq,
+		       (unsigned long long)steal,
+		       (unsigned long long)user,
+		       (unsigned long long)nice,
+		       (unsigned long long)system,
+		       (unsigned long long)idle,
+		       (unsigned long long)iowait,
+		       (unsigned long long)irq,
+		       (unsigned long long)softirq,
+		       (unsigned long long)steal,
+		       nprocs,
+		       runnable);
+	if (len < 0)
+		return -1;
+	if (len >= (int)count)
+	{
+		buf[count - 1] = '\0';
+		return (int)(count - 1);
+	}
+	buf[len] = '\0';
+	return len;
+}
+
 /* /proc/version: raw data only. One line: version\tdate\ttime\tuser\thost\tcompiler */
 int proc_version_read(char *buf, size_t count)
 {
@@ -1254,9 +1334,13 @@ static int proc_readdir_add(struct vfs_dirent *entries, int max_entries, int n,
 
 /*
  * Path-based readdir for /proc mounts (no virtual fds).
- * /proc          — registry children + "pid"
+ * /proc          — digit PIDs first, then "pid", then registry children
  * /proc/pid      — one dirent per live PID
- * /proc/pid/N    — status, cmdline
+ * /proc/pid/N    — status, cmdline, stat
+ *
+ * Digit PIDs must come first: sys_getdents uses GETDENTS_BATCH_MAX (24) and
+ * truncates; BusyBox top/ps scan only numeric dirents then open /proc/N/stat.
+ * Filling the batch with static registry names alone yields "no process info".
  */
 int proc_readdir(const char *path, struct vfs_dirent *entries, int max_entries)
 {
@@ -1273,14 +1357,7 @@ int proc_readdir(const char *path, struct vfs_dirent *entries, int max_entries)
         unsigned long irqf;
 
         pseudo_fs_nodes_register_all();
-        n = pseudo_fs_collect_registry_children("/proc", entries, max_entries, 0);
-        if (n < 0)
-            return n;
-        n = proc_readdir_add(entries, max_entries, n, "pid", DT_DIR);
-        /*
-         * BusyBox ps scans /proc for digit dirents then opens /proc/N/stat.
-         * Listing only "pid/" left ps empty.
-         */
+        n = 0;
         irqf = irq_save();
         for (p = process_list; p && n < max_entries; p = p->next)
         {
@@ -1295,6 +1372,17 @@ int proc_readdir(const char *path, struct vfs_dirent *entries, int max_entries)
             n = proc_readdir_add(entries, max_entries, n, pid_str, DT_DIR);
         }
         irq_restore(irqf);
+        n = proc_readdir_add(entries, max_entries, n, "pid", DT_DIR);
+        if (n < max_entries)
+        {
+            int reg;
+
+            reg = pseudo_fs_collect_registry_children("/proc", entries,
+                                                     max_entries, n);
+            if (reg < 0)
+                return reg;
+            n = reg;
+        }
         return n;
     }
 

--- a/fs/pseudo_fs_nodes.c
+++ b/fs/pseudo_fs_nodes.c
@@ -531,6 +531,8 @@ void pseudo_fs_nodes_register_all(void)
                        (void *)(uintptr_t)proc_boot_cmdline_read);
     pseudo_fs_register("/proc", "uptime", &proc_static_read_ops,
                        (void *)(uintptr_t)proc_uptime_read);
+    pseudo_fs_register("/proc", "stat", &proc_static_read_ops,
+                       (void *)(uintptr_t)proc_stat_read);
     pseudo_fs_register("/proc", "meminfo", &proc_static_read_ops,
                        (void *)(uintptr_t)proc_meminfo_read);
     pseudo_fs_register("/proc", "ps", &proc_static_read_ops,

--- a/includes/ir0/procfs.h
+++ b/includes/ir0/procfs.h
@@ -77,6 +77,7 @@ int proc_pid_stat_read(char *buf, size_t count, pid_t pid);
 const char *proc_resolve_path(const char *path, pid_t *pid_out);
 int proc_is_virtual_subdir(const char *path);
 int proc_uptime_read(char *buf, size_t count);
+int proc_stat_read(char *buf, size_t count);
 int proc_version_read(char *buf, size_t count);
 int proc_boot_cmdline_read(char *buf, size_t count);
 int proc_cpuinfo_read(char *buf, size_t count);

--- a/scripts/inject_init_minix.py
+++ b/scripts/inject_init_minix.py
@@ -201,9 +201,9 @@ def collect_used_inodes(f, sb):
 
 
 def sync_imap_from_tree(f, sb):
-    """Mark every in-use inode in the imap (bit set = allocated)."""
+    """Rebuild imap from the live tree (+ orphan inodes with mode/nlinks)."""
     used = collect_used_inodes(f, sb)
-    imap = bytearray(read_block(f, imap_block(sb)))
+    imap = bytearray(BLOCK)  # bit set = allocated; start empty then mark used
     for n in used:
         byte_i = n // 8
         bit_i = n % 8
@@ -426,6 +426,13 @@ def format_minix_v1(f, ninodes=64, nzones=1024):
         if blk == 0:
             zmap[0] &= ~(1 << 0)
         write_block(f, zmap_base + blk, bytes(zmap))
+
+    # Wipe inode table. Re-format of a previously packed image must not leave
+    # stale mode!=0 inodes: sync_imap_from_tree would mark them used and the
+    # next pack runs out of free inodes / corrupts root dentries (missing /etc).
+    itab = 2 + imap_blocks + zmap_blocks
+    for blk in range(inode_table_blocks):
+        write_block(f, itab + blk, bytes(BLOCK))
 
     root_zone = sb["firstdatazone"]
     root_inode = {
@@ -840,9 +847,9 @@ def main():
         disk_path = sys.argv[2]
         with open(disk_path, "r+b") as f:
             if sys.argv[1] == "--format-large":
-                # Headroom for TinyCC headers/libs + GNU make + samples
-                # (product runit rootfs alone uses ~50 inodes).
-                format_minix_v1(f, ninodes=1024, nzones=65535)
+                # Headroom for TinyCC headers/libs + GNU make + BusyBox applets.
+                # (Must wipe inode table — see format_minix_v1 — or re-pack fails.)
+                format_minix_v1(f, ninodes=2048, nzones=65535)
             else:
                 format_minix_v1(f)
         vprint(f"format {disk_path} MINIX v1")

--- a/scripts/make/isd.mk
+++ b/scripts/make/isd.mk
@@ -140,6 +140,8 @@ check-userspace: check-isd
 # Ensure per-PROFILE disk is up to date with stamps / .isdconfig.
 # Always runs ISD image-minix (incremental): rebuilds when config or packages change.
 ensure-isd-disk: check-isd
+	@echo "ISD disk    PROFILE=$(ISD_PROFILE) → $(IR0_ISD_DISK)"
+	@echo "            (first pack or format-large can take 1–3 min; stamps skip work when clean)"
 	+@$(IR0_ISD_MAKE) fetch
 	+@$(IR0_ISD_MAKE) image-minix
 	@test -f "$(IR0_ISD_DISK)" || { \
@@ -172,6 +174,7 @@ run-isd: kernel-x64-userspace.iso ensure-isd-disk
 	@echo "  DISK     $(IR0_ISD_DISK)"
 	@echo "  ISO      kernel-x64-userspace.iso"
 	@echo "  Ungrab:  Ctrl+Alt+G"
+	@echo "  Guest:   first-boot wizard or login (development = autologin root)"
 	qemu-system-x86_64 -cdrom kernel-x64-userspace.iso \
 		-drive file=$(IR0_ISD_DISK),format=raw,if=ide,index=0 \
 		$(QEMU_NET_ALL) $(QEMU_AUDIO_ALL) $(QEMU_SERIAL_COM1) $(QEMU_ISA_DEBUG_EXIT) \

--- a/scripts/smoke_ash_direct_segv_probe.py
+++ b/scripts/smoke_ash_direct_segv_probe.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""
+Reproduce ash SEGV without getty/login.
+
+Replaces console/run with ash_direct_console_run (interactive -sh -i on
+/dev/console), injects keystrokes via QEMU HMP (Tab / ulimit), and greps
+serial for userspace segv / probe tags.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ISD = ROOT.parent / "ISD"
+DEFAULT_TIMEOUT = 70
+MONITOR_PORT = 4555
+
+FAIL_RES = [
+    re.compile(r"KERNEL PANIC"),
+    re.compile(r"DOUBLE PANIC"),
+]
+
+
+def monitor_send(port: int, cmd: str) -> None:
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(2)
+        try:
+            sock.recv(4096)
+        except socket.timeout:
+            pass
+        sock.sendall((cmd.strip() + "\r\n").encode("ascii"))
+        time.sleep(0.05)
+        try:
+            sock.recv(4096)
+        except socket.timeout:
+            pass
+
+
+def send_keys(port: int, keys: list[str]) -> None:
+    for k in keys:
+        monitor_send(port, f"sendkey {k}")
+        time.sleep(0.08)
+
+
+def log_text(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iso", default=str(ROOT / "kernel-x64-userspace.iso"))
+    ap.add_argument(
+        "--disk-src",
+        default=str(ISD / "out/x86_64/images/development/disk.img"),
+    )
+    ap.add_argument("--log", default="/tmp/ash-direct-segv-probe.log")
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--monitor-port", type=int, default=MONITOR_PORT)
+    args = ap.parse_args()
+
+    smoke_bin = ISD / "out/x86_64/smoke/stage-bin"
+    direct = smoke_bin / "ash_direct_console_run"
+    if not direct.is_file():
+        print(f"✗ missing {direct} — build ISD smoke first", file=sys.stderr)
+        return 2
+
+    log_path = Path(args.log)
+    if log_path.exists():
+        log_path.unlink()
+
+    disk = Path(tempfile.mktemp(prefix="ir0-ash-direct.", suffix=".img"))
+    shutil.copy2(args.disk_src, disk)
+
+    inj = subprocess.run(
+        [
+            str(ISD / "scripts/inject-smoke-service.sh"),
+            "--run-only",
+            str(disk),
+            "console",
+            str(direct),
+        ],
+        check=False,
+    )
+    if inj.returncode != 0:
+        print("✗ inject console→ash_direct failed", file=sys.stderr)
+        disk.unlink(missing_ok=True)
+        return 2
+
+    mon = args.monitor_port
+    qemu_cmd = [
+        "qemu-system-x86_64",
+        "-cdrom",
+        args.iso,
+        "-drive",
+        f"file={disk},format=raw,if=ide,index=0",
+        "-serial",
+        "stdio",
+        "-display",
+        "none",
+        "-m",
+        "256M",
+        "-no-reboot",
+        "-net",
+        "none",
+        "-monitor",
+        f"tcp:127.0.0.1:{mon},server,nowait",
+    ]
+
+    env = os.environ.copy()
+    with log_path.open("w") as logf:
+        proc = subprocess.Popen(
+            qemu_cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+
+    def kill_qemu(*_a: object) -> None:
+        if proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    keyed = False
+    t0 = time.time()
+    try:
+        while time.time() - t0 < args.timeout:
+            text = log_text(log_path)
+            for fr in FAIL_RES:
+                if fr.search(text):
+                    print("FAIL: panic in log")
+                    kill_qemu()
+                    return 1
+            if "GETTY_READY" in text or "LOGIN_USER_READ" in text:
+                print("FAIL: getty/login ran (console replace ineffective)")
+                kill_qemu()
+                return 1
+            if not keyed and "ASH_DIRECT_START" in text:
+                # Give ash a moment to print prompt
+                time.sleep(1.5)
+                # Guest listed PATH via Tab; also force a large /bin listing.
+                for _ in range(4):
+                    send_keys(mon, ["tab"])
+                    time.sleep(0.4)
+                send_keys(
+                    mon,
+                    [
+                        "l",
+                        "s",
+                        "spc",
+                        "slash",
+                        "b",
+                        "i",
+                        "n",
+                        "ret",
+                    ],
+                )
+                time.sleep(1.5)
+                send_keys(
+                    mon,
+                    ["u", "l", "i", "m", "i", "t", "ret"],
+                )
+                time.sleep(0.8)
+                send_keys(
+                    mon,
+                    [
+                        "e",
+                        "x",
+                        "e",
+                        "c",
+                        "spc",
+                        "minus",
+                        "minus",
+                        "v",
+                        "e",
+                        "r",
+                        "s",
+                        "i",
+                        "o",
+                        "n",
+                        "ret",
+                    ],
+                )
+                time.sleep(0.5)
+                # Extra stress: ulimit -a then another Tab
+                send_keys(
+                    mon,
+                    ["u", "l", "i", "m", "i", "t", "spc", "minus", "a", "ret"],
+                )
+                time.sleep(0.5)
+                send_keys(mon, ["tab", "tab"])
+                keyed = True
+                time.sleep(3.0)
+            if keyed and "userspace segv" in text:
+                print("RESULT: SEGV reproduced (interactive ash, no getty)")
+                kill_qemu()
+                print(f"log: {log_path}")
+                return 0
+            if keyed and time.time() - t0 > 40:
+                break
+            time.sleep(0.25)
+    finally:
+        kill_qemu()
+        disk.unlink(missing_ok=True)
+
+    text = log_text(log_path)
+    print("=== tags / PF (tail) ===")
+    for line in text.splitlines():
+        if any(
+            s in line
+            for s in (
+                "ASH_DIRECT",
+                "userspace segv",
+                "GETTY",
+                "LOGIN_",
+                "unlimited",
+                "illegal option",
+            )
+        ):
+            print(line)
+
+    if "userspace segv" in text:
+        print("RESULT: SEGV reproduced")
+        return 0
+    if "ASH_DIRECT_START" not in text:
+        print("RESULT: ash direct never started")
+        return 1
+    print("RESULT: no SEGV after Tab+ulimit+exec (interactive, no getty)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_console_session_fork.py
+++ b/scripts/smoke_console_session_fork.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""
+Validate console fork+wait: after ash `exit`, getty re-prompts without
+respawning the runit service (no second RUNSV_CONSOLE_START).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ISD = ROOT.parent / "ISD"
+DEFAULT_TIMEOUT = 75
+MONITOR_PORT = 4560
+
+
+def monitor_send(port: int, cmd: str) -> None:
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(2)
+        try:
+            sock.recv(4096)
+        except socket.timeout:
+            pass
+        sock.sendall((cmd.strip() + "\r\n").encode("ascii"))
+        time.sleep(0.05)
+        try:
+            sock.recv(4096)
+        except socket.timeout:
+            pass
+
+
+def send_keys(port: int, keys: list[str], delay: float = 0.1) -> None:
+    for k in keys:
+        monitor_send(port, f"sendkey {k}")
+        time.sleep(delay)
+
+
+def log_text(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iso", default=str(ROOT / "kernel-x64-userspace.iso"))
+    ap.add_argument(
+        "--disk-src",
+        default=str(ISD / "out/x86_64/images/development/disk.img"),
+    )
+    ap.add_argument(
+        "--console-bin",
+        default=str(ISD / "out/x86_64/product/stage-bin/runit_console_run"),
+    )
+    ap.add_argument("--log", default="/tmp/console-session-fork-smoke.log")
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT)
+    ap.add_argument("--monitor-port", type=int, default=MONITOR_PORT)
+    args = ap.parse_args()
+
+    console = Path(args.console_bin)
+    if not console.is_file():
+        print(f"✗ missing {console}", file=sys.stderr)
+        return 2
+
+    log_path = Path(args.log)
+    log_path.unlink(missing_ok=True)
+
+    disk = Path(tempfile.mktemp(prefix="ir0-console-fork.", suffix=".img"))
+    shutil.copy2(args.disk_src, disk)
+
+    inj = subprocess.run(
+        [
+            str(ISD / "scripts/inject-smoke-service.sh"),
+            "--run-only",
+            str(disk),
+            "console",
+            str(console),
+        ],
+        check=False,
+    )
+    if inj.returncode != 0:
+        print("✗ inject console failed", file=sys.stderr)
+        disk.unlink(missing_ok=True)
+        return 2
+
+    mon = args.monitor_port
+    qemu_cmd = [
+        "qemu-system-x86_64",
+        "-cdrom",
+        args.iso,
+        "-drive",
+        f"file={disk},format=raw,if=ide,index=0",
+        "-serial",
+        f"file:{log_path}",
+        "-display",
+        "none",
+        "-m",
+        "256M",
+        "-no-reboot",
+        "-net",
+        "none",
+        "-monitor",
+        f"tcp:127.0.0.1:{mon},server,nowait",
+    ]
+
+    proc = subprocess.Popen(
+        qemu_cmd,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    def kill_qemu() -> None:
+        if proc.poll() is None:
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+    exited = False
+    t0 = time.time()
+    try:
+        while time.time() - t0 < args.timeout:
+            text = log_text(log_path)
+            if re.search(r"KERNEL PANIC", text):
+                print("FAIL: panic")
+                kill_qemu()
+                return 1
+            if not exited and "ASH_INTERACTIVE_READY" in text:
+                time.sleep(1.0)
+                send_keys(mon, ["e", "x", "i", "t", "ret"])
+                exited = True
+            if exited and "CONSOLE_SESSION_REPROMPT" in text:
+                # Success criteria
+                starts = text.count("RUNSV_CONSOLE_START")
+                if starts != 1:
+                    print(f"FAIL: RUNSV_CONSOLE_START count={starts} (want 1)")
+                    kill_qemu()
+                    return 1
+                if "CONSOLE_SESSION_START" not in text:
+                    print("FAIL: missing CONSOLE_SESSION_START")
+                    kill_qemu()
+                    return 1
+                if "CONSOLE_SESSION_END" not in text and "CONSOLE_SESSION_SEGV" not in text:
+                    print("FAIL: missing CONSOLE_SESSION_END/SEGV")
+                    kill_qemu()
+                    return 1
+                print("PASS: session ended; console re-prompted without service restart")
+                print(f"log: {log_path}")
+                kill_qemu()
+                return 0
+            time.sleep(0.25)
+    finally:
+        kill_qemu()
+        disk.unlink(missing_ok=True)
+
+    text = log_text(log_path)
+    print("FAIL: timeout")
+    for line in text.splitlines():
+        if any(
+            s in line
+            for s in (
+                "RUNSV_CONSOLE",
+                "CONSOLE_SESSION",
+                "ASH_INTERACTIVE",
+                "LOGIN_",
+                "GETTY",
+            )
+        ):
+            print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_proc_coherence.py
+++ b/scripts/smoke_proc_coherence.py
@@ -101,6 +101,7 @@ def main() -> int:
             "date",
             "cat /proc/uptime",
             "cat /proc/loadavg",
+            "cat /proc/stat",
             "cat /proc/meminfo",
             "cat /proc/iomem",
             "echo PROC_COH_DONE",
@@ -120,6 +121,13 @@ def main() -> int:
             ok = False
         if not re.search(r"\d+\.\d{2}\s+\d+\.\d{2}\s+\d+\.\d{2}\s+\d+/\d+\s+\d+", text):
             print("✗ /proc/loadavg format missing", file=sys.stderr)
+            ok = False
+        # BusyBox top needs "cpu" + ≥4 jiffy fields (user nice system idle …)
+        if not re.search(r"(?m)^cpu\s+\d+\s+\d+\s+\d+\s+\d+", text):
+            print("✗ /proc/stat cpu line missing", file=sys.stderr)
+            ok = False
+        if not re.search(r"(?m)^cpu0\s+\d+\s+\d+\s+\d+\s+\d+", text):
+            print("✗ /proc/stat cpu0 line missing", file=sys.stderr)
             ok = False
         if "MemTotal:" not in text or "kB" not in text:
             print("✗ /proc/meminfo labels missing", file=sys.stderr)
@@ -144,11 +152,17 @@ def main() -> int:
                         "202",
                         "System RAM",
                         "PROC_COH",
+                        "cpu ",
+                        "cpu0",
                         ".",
                     )
                 ):
-                    if "Mem" in line or "RAM" in line or "PROC" in line or re.search(
-                        r"\d+\.\d{2}", line
+                    if (
+                        "Mem" in line
+                        or "RAM" in line
+                        or "PROC" in line
+                        or line.startswith("cpu")
+                        or re.search(r"\d+\.\d{2}", line)
                     ):
                         print(line)
             return 0

--- a/scripts/smoke_proc_stat_top.py
+++ b/scripts/smoke_proc_stat_top.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""Guest smoke: /proc/stat present and BusyBox top -bn1 does not die on it."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ISD = ROOT.parent / "ISD"
+PROMPT_RE = re.compile(r"root@ir0:[^\s#$]+[#$]")
+
+
+def mon(port: int, cmd: str, delay: float = 0.05) -> None:
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as s:
+        s.settimeout(0.5)
+        try:
+            s.recv(4096)
+        except OSError:
+            pass
+        s.sendall((cmd + "\n").encode())
+        time.sleep(delay)
+        try:
+            s.recv(4096)
+        except OSError:
+            pass
+
+
+def type_line(port: int, line: str) -> None:
+    special = {
+        " ": "spc",
+        "/": "slash",
+        "-": "minus",
+        ".": "dot",
+        "_": "shift-minus",
+        ":": "shift-semicolon",
+    }
+    for ch in line:
+        if ch in special:
+            mon(port, f"sendkey {special[ch]}", 0.12)
+        elif ch.isupper():
+            mon(port, f"sendkey shift-{ch.lower()}", 0.12)
+        else:
+            mon(port, f"sendkey {ch}", 0.12)
+    mon(port, "sendkey ret", 0.35)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iso", default=str(ROOT / "kernel-x64-userspace.iso"))
+    ap.add_argument(
+        "--disk-src",
+        default=str(ISD / "out/x86_64/images/development/disk.img"),
+    )
+    ap.add_argument("--monitor-port", type=int, default=4564)
+    ap.add_argument("--timeout", type=int, default=70)
+    args = ap.parse_args()
+
+    iso = Path(args.iso)
+    disk_src = Path(args.disk_src)
+    if not iso.is_file() or not disk_src.is_file():
+        print(f"✗ need iso ({iso}) and disk ({disk_src})", file=sys.stderr)
+        return 2
+
+    log = Path(tempfile.mkstemp(prefix="ir0-proc-stat-", suffix=".log")[1])
+    disk = Path(tempfile.mktemp(prefix="ir0-proc-stat.", suffix=".img"))
+    shutil.copy2(disk_src, disk)
+    port = args.monitor_port
+
+    qemu = [
+        "qemu-system-x86_64",
+        "-cdrom",
+        str(iso),
+        "-drive",
+        f"file={disk},format=raw,if=ide,index=0",
+        "-serial",
+        "stdio",
+        "-display",
+        "none",
+        "-m",
+        "256M",
+        "-no-reboot",
+        "-net",
+        "none",
+        "-monitor",
+        f"tcp:127.0.0.1:{port},server,nowait",
+    ]
+    with log.open("w") as lf:
+        proc = subprocess.Popen(
+            qemu, stdout=lf, stderr=subprocess.STDOUT, cwd=str(ROOT)
+        )
+    try:
+        deadline = time.time() + args.timeout
+        text = ""
+        while time.time() < deadline:
+            text = log.read_text(errors="replace")
+            if PROMPT_RE.search(text) and "ASH_INTERACTIVE_READY" in text:
+                break
+            if proc.poll() is not None:
+                print("✗ qemu exited early", file=sys.stderr)
+                print(text[-3000:], file=sys.stderr)
+                return 1
+            time.sleep(0.3)
+        else:
+            print("✗ timeout waiting for root shell", file=sys.stderr)
+            print(text[-3000:], file=sys.stderr)
+            return 1
+
+        # Autologin shell is ready; give the console a beat before HMP sendkey.
+        time.sleep(3.0)
+        for cmd in ("cat /proc/stat", "echo STAT_OK", "top -bn1", "echo TOP_OK"):
+            type_line(port, cmd)
+            time.sleep(2.5)
+
+        time.sleep(1.5)
+        text = log.read_text(errors="replace")
+        ok = True
+        if not re.search(r"(?m)^cpu\s+\d+\s+\d+\s+\d+\s+\d+", text):
+            print("✗ /proc/stat cpu line missing", file=sys.stderr)
+            ok = False
+        if not re.search(r"(?m)^cpu0\s+\d+\s+\d+\s+\d+\s+\d+", text):
+            print("✗ /proc/stat cpu0 line missing", file=sys.stderr)
+            ok = False
+        if "STAT_OK" not in text:
+            print("✗ STAT_OK marker missing", file=sys.stderr)
+            ok = False
+        if "can't open 'stat'" in text or "can't read '/proc/stat'" in text:
+            print("✗ BusyBox top failed on /proc/stat", file=sys.stderr)
+            ok = False
+        if "no process info in /proc" in text:
+            print("✗ BusyBox top: no process info (getdents PID list)", file=sys.stderr)
+            ok = False
+        # top -bn1 header proves jiffy parse + process scan (primary BusyBox contract)
+        if "Mem:" not in text or "CPU:" not in text:
+            print("✗ top -bn1 header missing", file=sys.stderr)
+            ok = False
+        if "TOP_OK" not in text:
+            print("✗ TOP_OK marker missing (top may have aborted)", file=sys.stderr)
+            ok = False
+        if ok:
+            print("✓ smoke-proc-stat-top OK")
+            for line in text.splitlines():
+                if line.startswith("cpu") or line in ("STAT_OK", "TOP_OK"):
+                    print(line)
+                if "Mem:" in line or "CPU:" in line or "Load average" in line:
+                    print(line)
+            return 0
+        print(text[-5000:], file=sys.stderr)
+        return 1
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        disk.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Añade `/proc/stat` (líneas `cpu`/`cpu0`) para que BusyBox `top` deje de fallar con `can't open 'stat'`.
- Prioriza dirents PID en `proc_readdir` frente al registry estático (`GETDENTS_BATCH_MAX=24`).
- Bounce ATA + gate MINIX para buffers impares (storms de alineación).
- Docs EN/ES + smokes `smoke_proc_stat_top` / console fork / ash SEGV probe.

## Test plan
- [x] `make kernel-x64.bin` + `make arch-guard`
- [x] `python3 scripts/smoke_proc_stat_top.py` (ISD development disk)
- [ ] Manual: `make run PROFILE=development` → `cat /proc/stat` → `top`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ATA PIO and MINIX I/O fast paths plus procfs listing order—core block and observability behavior—but no auth or syscall ABI breaks; rootfs format changes affect ISD disk packing reliability.
> 
> **Overview**
> Enables **BusyBox `top`** by adding Linux-shaped **`/proc/stat`** (`cpu`/`cpu0` jiffy lines via `proc_stat_read`) and reordering **`proc_readdir("/proc")`** so numeric PID dirents appear before static registry names—avoiding truncation at **`GETDENTS_BATCH_MAX` (24)** that left `top`/`ps` with no process list.
> 
> **Storage:** ATA read/write now **bounce odd-aligned userspace buffers** through a 512-byte aligned sector buffer; MINIX skips the block fast-path when dst/src is odd, reducing **`ATA_BUFFER_ALIGNMENT_SUSPECT`** noise. **`inject_init_minix.py --format-large`** wipes the inode table, rebuilds imap from the live tree, and bumps large images to **2048 inodes** so re-pack does not inherit stale inodes (fixes missing `/etc` on inject).
> 
> **Tooling/docs:** Guest smokes (`smoke_proc_stat_top.py`, `/proc/stat` in `smoke_proc_coherence.py`, plus console-fork and ash SEGV probes), ISD pack progress hints in `isd.mk`, and EN/ES docs (VFS, processes/reparent, ISD bootstrap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bbaa3c7be8601a5f74d55d2a07617b7d68bdcef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->