### PR TITLE
Enhance /proc/stat, fix MINIX inode handling, and improve user space stability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1457,6 +1457,7 @@ INIT_MUSL_SRC  = setup/pid1/init_musl.c
 MUSL_ARCH_PRCTL_SMOKE_SRC = setup/pid1/musl_arch_prctl_smoke.c
 MUSL_PTHREAD_SMOKE_SRC = setup/pid1/musl_pthread_smoke.c
 SETUID_EXEC_SMOKE_SRC = setup/pid1/setuid_exec_smoke.c
+CHROOT_SMOKE_SRC = setup/pid1/chroot_smoke.c
 SETID_HELPER_SRC = setup/pid1/setid_helper.c
 PASSWD_SMOKE_SRC = $(IR0_USERSPACE_ROOT)/smoke/passwd_smoke.c
 DOAS_SMOKE_SRC = $(IR0_USERSPACE_ROOT)/smoke/doas_smoke.c
@@ -1553,6 +1554,7 @@ INIT_SMOKE_BIN   = setup/pid1/init
 MUSL_ARCH_PRCTL_BIN = setup/pid1/musl_arch_prctl_smoke
 MUSL_PTHREAD_SMOKE_BIN = setup/pid1/musl_pthread_smoke
 SETUID_EXEC_SMOKE_BIN = setup/pid1/setuid_exec_smoke
+CHROOT_SMOKE_BIN = setup/pid1/chroot_smoke
 SETID_HELPER_BIN = setup/pid1/setid_helper
 PASSWD_SMOKE_BIN = $(IR0_USERSPACE_OUT)/smoke/passwd_smoke
 SH_SMOKE_BIN     = setup/pid1/sh_smoke
@@ -1599,6 +1601,7 @@ FASE55D_DOOMGENERIC_LOG = /tmp/userspace-fase55d-doomgeneric.log
 MUSL_ARCH_PRCTL_LOG = /tmp/userspace-musl-arch-prctl.log
 MUSL_PTHREAD_SMOKE_LOG = /tmp/userspace-musl-pthread.log
 SETUID_EXEC_SMOKE_LOG = /tmp/userspace-setuid-exec.log
+CHROOT_SMOKE_LOG = /tmp/userspace-chroot.log
 PASSWD_SMOKE_LOG = /tmp/userspace-passwd.log
 FASE55E_DOOM_BIN = setup/pid1/fase55e_doom_interactive
 FASE55E_DOOM_GUI_LOG = /tmp/fase55e-doomgeneric-gui.log
@@ -1736,6 +1739,18 @@ build-setuid-exec-smoke:
 	@strings $(SETUID_EXEC_SMOKE_BIN) 2>/dev/null | grep -q "SETUID_EXEC_ALL_OK" || \
 		(echo "✗ setuid smoke missing SETUID_EXEC_ALL_OK string"; exit 1)
 	@echo "✓ build-setuid-exec-smoke OK"
+
+build-chroot-smoke:
+	@if [ -z "$(MUSL_CC)" ]; then \
+		echo "✗ musl cross compiler not found (install musl-tools or set MUSL_CC=...)"; \
+		exit 1; \
+	fi
+	@echo "  MUSL    Building chroot smoke ($(CHROOT_SMOKE_BIN))"
+	@$(MUSL_CC) -static -Os -o $(CHROOT_SMOKE_BIN) $(CHROOT_SMOKE_SRC)
+	@file $(CHROOT_SMOKE_BIN) | grep -q ELF
+	@strings $(CHROOT_SMOKE_BIN) 2>/dev/null | grep -q "CHROOT_OK" || \
+		(echo "✗ chroot smoke missing CHROOT_OK string"; exit 1)
+	@echo "✓ build-chroot-smoke OK"
 
 build-passwd-smoke:
 	@if [ -z "$(MUSL_CC)" ]; then \
@@ -2454,6 +2469,23 @@ smoke-desktop-nano: kernel-x64-userspace.iso
 	@IR0_PRODUCT_PROFILE=development IR0_NO_AUTOLOGIN=0 $(MAKE) -s load-userspace-runit
 	@chmod +x scripts/smoke_desktop_nano_mnt.py
 	@python3 scripts/smoke_desktop_nano_mnt.py --iso kernel-x64-userspace.iso --disk disk.img
+
+# Product binaries stress: top quit, man, dmesg/pipes, tcc hello, optional doom.
+# Uses ISD development disk (top/man/tcc). Doom only if DOOM1.WAD is on the host.
+USERSPACE_STABILITY_LOG = /tmp/ir0-userspace-stability.log
+USERSPACE_STABILITY_DISK ?= $(IR0_USERSPACE_ROOT)/out/x86_64/images/development/disk.img
+.PHONY: smoke-userspace-stability
+smoke-userspace-stability: kernel-x64-userspace.iso
+	@echo "  SMOKE   userspace stability (top/man/tcc/pipes[+doom])..."
+	@test -f $(USERSPACE_STABILITY_DISK) || \
+		{ echo "✗ missing $(USERSPACE_STABILITY_DISK) — pack ISD development first"; exit 2; }
+	@chmod +x scripts/smoke_userspace_stability.py scripts/smoke_desktop_cmd_matrix.py
+	@python3 scripts/smoke_userspace_stability.py \
+		--iso kernel-x64-userspace.iso \
+		--disk $(USERSPACE_STABILITY_DISK) \
+		--log $(USERSPACE_STABILITY_LOG) \
+		--auto-doom
+	@echo "  LOG     $(USERSPACE_STABILITY_LOG)"
 
 # Non-root path: crypt(3) auth + setuid drop + /etc/profile PS1 (typed via monitor).
 RUNIT_LOGIN_NONROOT_SMOKE_LOG = /tmp/runit-login-nonroot-smoke.log
@@ -6046,6 +6078,30 @@ smoke-setuid-exec: build-setuid-exec-smoke kernel-x64-userspace.iso
 			  grep -E 'SETID_|SETUID_' $(SETUID_EXEC_SMOKE_LOG) | tail -20; exit 1; }; \
 	done
 	@echo "✓ smoke-setuid-exec passed"
+
+CHROOT_SMOKE_TAGS = CHROOT_OPEN_INSIDE_OK CHROOT_OUTSIDE_DENIED CHROOT_GETCWD_OK \
+	CHROOT_FORK_INHERIT_OK CHROOT_OK
+
+.PHONY: build-chroot-smoke smoke-chroot
+smoke-chroot: build-chroot-smoke kernel-x64-userspace.iso
+	@echo "  SMOKE   chroot(2) jail remap + fork inherit..."
+	@DISK=$$(mktemp /tmp/ir0-chroot-smoke.XXXXXX.img); \
+	dd if=/dev/zero of=$$DISK bs=1M count=64 status=none && \
+	python3 scripts/inject_init_minix.py --format-large $$DISK && \
+	python3 scripts/inject_init_minix.py $$DISK $(CHROOT_SMOKE_BIN) sbin/init && \
+	python3 scripts/verify_minix_rootfs.py $$DISK /sbin/init && \
+	$(SMOKE_QEMU_RUN) --log $(CHROOT_SMOKE_LOG) --timeout 60 --stale-sec 20 \
+		--done CHROOT_OK --fail-regex 'CHROOT_FAIL|KERNEL PANIC' -- \
+		$(QEMU) -cdrom kernel-x64-userspace.iso \
+		-drive file=$$DISK,format=raw,if=ide,index=0 \
+		-serial stdio -display none -m 128M -no-reboot -net none; \
+	rm -f $$DISK;
+	@for tag in $(CHROOT_SMOKE_TAGS); do \
+		grep -q "$$tag" $(CHROOT_SMOKE_LOG) || \
+			{ echo "✗ smoke-chroot FAILED (missing $$tag)"; \
+			  grep -E 'CHROOT_' $(CHROOT_SMOKE_LOG) | tail -30; exit 1; }; \
+	done
+	@echo "✓ smoke-chroot passed"
 
 smoke-musl-pthread: build-musl-pthread-smoke kernel-x64-userspace.iso
 	@echo "  SMOKE   musl pthread_create + join..."

--- a/drivers/timer/clock_system.c
+++ b/drivers/timer/clock_system.c
@@ -632,6 +632,11 @@ int clock_take_sched_resched_pending(void)
     return pending;
 }
 
+int clock_sched_resched_pending_peek(void)
+{
+    return clock_state.sched_resched_pending ? 1 : 0;
+}
+
 void clock_request_sched_resched(void)
 {
     clock_state.sched_resched_pending = 1;

--- a/drivers/timer/clock_system.h
+++ b/drivers/timer/clock_system.h
@@ -141,6 +141,7 @@ void clock_cancel_all_alarms(void);
 int clock_set_scheduler_quantum(uint32_t ticks);
 uint32_t clock_get_scheduler_quantum(void);
 int clock_take_sched_resched_pending(void);
+int clock_sched_resched_pending_peek(void);
 void clock_request_sched_resched(void);
 
 /* Statistics */

--- a/fs/path.c
+++ b/fs/path.c
@@ -199,3 +199,104 @@ int get_parent_path(const char *path, char *dest, size_t size)
     dest[parent_len] = '\0';
     return 0;
 }
+
+int ir0_path_apply_root(const char *root, const char *abs_user,
+			char *dest, size_t size)
+{
+	char norm_user[256];
+	char norm_root[256];
+
+	if (!abs_user || !dest || size == 0)
+		return -1;
+
+	if (normalize_path(abs_user, norm_user, sizeof(norm_user)) != 0)
+		return -1;
+
+	if (!root || root[0] == '\0' ||
+	    (root[0] == '/' && root[1] == '\0'))
+		return normalize_path(norm_user, dest, size);
+
+	if (normalize_path(root, norm_root, sizeof(norm_root)) != 0)
+		return -1;
+
+	/* User "/" → the jail root itself. */
+	if (norm_user[0] == '/' && norm_user[1] == '\0')
+		return normalize_path(norm_root, dest, size);
+
+	/* join_paths ignores base when rel is absolute — strip leading '/'. */
+	return join_paths(norm_root, norm_user + 1, dest, size);
+}
+
+int ir0_path_under_root(const char *root, const char *cwd)
+{
+	char norm_root[256];
+	char norm_cwd[256];
+	size_t rlen;
+
+	if (!cwd || cwd[0] != '/')
+		return 0;
+	if (!root || root[0] == '\0' ||
+	    (root[0] == '/' && root[1] == '\0'))
+		return 1;
+
+	if (normalize_path(root, norm_root, sizeof(norm_root)) != 0)
+		return 0;
+	if (normalize_path(cwd, norm_cwd, sizeof(norm_cwd)) != 0)
+		return 0;
+
+	rlen = strlen(norm_root);
+	if (strcmp(norm_cwd, norm_root) == 0)
+		return 1;
+	if (strncmp(norm_cwd, norm_root, rlen) != 0)
+		return 0;
+	return norm_cwd[rlen] == '/';
+}
+
+int ir0_path_getcwd_visible(const char *root, const char *cwd,
+			    char *dest, size_t size)
+{
+	char norm_root[256];
+	char norm_cwd[256];
+	size_t rlen;
+	const char *vis;
+
+	if (!cwd || !dest || size == 0)
+		return -1;
+
+	if (normalize_path(cwd, norm_cwd, sizeof(norm_cwd)) != 0)
+		return -1;
+
+	if (!root || root[0] == '\0' ||
+	    (root[0] == '/' && root[1] == '\0'))
+	{
+		if (strlen(norm_cwd) >= size)
+			return -1;
+		strncpy(dest, norm_cwd, size - 1);
+		dest[size - 1] = '\0';
+		return 0;
+	}
+
+	if (normalize_path(root, norm_root, sizeof(norm_root)) != 0)
+		return -1;
+
+	if (!ir0_path_under_root(norm_root, norm_cwd))
+	{
+		if (strlen(norm_cwd) >= size)
+			return -1;
+		strncpy(dest, norm_cwd, size - 1);
+		dest[size - 1] = '\0';
+		return 0;
+	}
+
+	rlen = strlen(norm_root);
+	if (strcmp(norm_cwd, norm_root) == 0)
+		vis = "/";
+	else
+		vis = norm_cwd + rlen; /* starts with '/' */
+
+	if (strlen(vis) >= size)
+		return -1;
+	strncpy(dest, vis, size - 1);
+	dest[size - 1] = '\0';
+	return 0;
+}

--- a/includes/ir0/clock.h
+++ b/includes/ir0/clock.h
@@ -122,6 +122,7 @@ void clock_cancel_all_alarms(void);
 int clock_set_scheduler_quantum(uint32_t ticks);
 uint32_t clock_get_scheduler_quantum(void);
 int clock_take_sched_resched_pending(void);
+int clock_sched_resched_pending_peek(void);
 
 /* Request cooperative reschedule at user-return (e.g. after waking a blocked task). */
 void clock_request_sched_resched(void);

--- a/includes/ir0/path.h
+++ b/includes/ir0/path.h
@@ -36,4 +36,25 @@ int is_absolute_path(const char *path);
 // Returns 0 on success, -1 on error
 int get_parent_path(const char *path, char *dest, size_t size);
 
+/*
+ * Map an absolute userspace path through a chroot root (host-absolute).
+ * root "/" or NULL → normalize abs_user only.
+ * Returns 0 on success, -1 on error.
+ */
+int ir0_path_apply_root(const char *root, const char *abs_user,
+			char *dest, size_t size);
+
+/*
+ * True if host-absolute cwd is at or under root (prefix + '/' or equal).
+ */
+int ir0_path_under_root(const char *root, const char *cwd);
+
+/*
+ * Path shown by getcwd(2): strip root prefix when cwd is under root;
+ * otherwise copy cwd (cwd outside jail after chroot without chdir).
+ * Returns 0 on success, -1 on error.
+ */
+int ir0_path_getcwd_visible(const char *root, const char *cwd,
+			    char *dest, size_t size);
+
 #endif /* _IR0_PATH_H */

--- a/includes/ir0/path_user.c
+++ b/includes/ir0/path_user.c
@@ -10,7 +10,8 @@
 #include <ir0/utimens.h>
 
 int ir0_resolve_kpath_at(int dirfd, const char *path, char *resolved,
-                         size_t resolved_sz, const char *cwd)
+                         size_t resolved_sz, const char *cwd,
+                         const char *root)
 {
     if (!path || !resolved || resolved_sz == 0)
         return -EINVAL;
@@ -20,7 +21,7 @@ int ir0_resolve_kpath_at(int dirfd, const char *path, char *resolved,
 
     if (path[0] == '/')
     {
-        if (normalize_path(path, resolved, resolved_sz) != 0)
+        if (ir0_path_apply_root(root, path, resolved, resolved_sz) != 0)
             return -ENAMETOOLONG;
         return 0;
     }
@@ -38,7 +39,8 @@ int ir0_resolve_kpath_at(int dirfd, const char *path, char *resolved,
 }
 
 int ir0_resolve_user_path_at(int dirfd, const char *user_path, char *resolved,
-                             size_t resolved_sz, const char *cwd)
+                             size_t resolved_sz, const char *cwd,
+                             const char *root)
 {
     char path_copy[256];
 
@@ -48,12 +50,14 @@ int ir0_resolve_user_path_at(int dirfd, const char *user_path, char *resolved,
     if (copy_from_user_cstring(path_copy, sizeof(path_copy), user_path) != 0)
         return -EFAULT;
 
-    return ir0_resolve_kpath_at(dirfd, path_copy, resolved, resolved_sz, cwd);
+    return ir0_resolve_kpath_at(dirfd, path_copy, resolved, resolved_sz, cwd,
+                                root);
 }
 
-int ir0_resolve_user_path(const char *user_path, char *resolved, size_t resolved_sz,
-                          const char *cwd)
+int ir0_resolve_user_path(const char *user_path, char *resolved,
+                          size_t resolved_sz, const char *cwd,
+                          const char *root)
 {
     return ir0_resolve_user_path_at(IR0_AT_FDCWD, user_path, resolved,
-                                    resolved_sz, cwd);
+                                    resolved_sz, cwd, root);
 }

--- a/includes/ir0/path_user.h
+++ b/includes/ir0/path_user.h
@@ -10,27 +10,28 @@
 #include <ir0/utimens.h>
 
 /*
- * ir0_resolve_kpath_at - Resolve kernel-side path against dirfd (AT_FDCWD subset).
- * Absolute paths ignore dirfd. Non-absolute paths require dirfd == IR0_AT_FDCWD.
+ * ir0_resolve_kpath_at - Resolve kernel-side path against dirfd + chroot.
+ * Absolute paths: mapped under @root (host-absolute jail).
+ * Relative paths: join @cwd (AT_FDCWD only); not forced under root (Linux).
+ * @root: process chroot (NULL or "/" = no jail).
  */
 int ir0_resolve_kpath_at(int dirfd, const char *path, char *resolved,
-                         size_t resolved_sz, const char *cwd);
+                         size_t resolved_sz, const char *cwd,
+                         const char *root);
 
 /*
  * ir0_resolve_user_path_at - Copy user path then ir0_resolve_kpath_at().
  */
 int ir0_resolve_user_path_at(int dirfd, const char *user_path, char *resolved,
-                             size_t resolved_sz, const char *cwd);
+                             size_t resolved_sz, const char *cwd,
+                             const char *root);
 
 /*
- * ir0_resolve_user_path - Copy NUL-terminated user path and resolve against cwd.
- * @user_path: Path pointer from userspace (may be on stack near guard page).
- * @resolved: Kernel buffer for absolute normalized path.
- * @resolved_sz: Size of @resolved.
- * @cwd: Current working directory (kernel string).
- * Returns: 0 on success, -EFAULT / -EINVAL / -ENAMETOOLONG on error.
+ * ir0_resolve_user_path - Copy NUL-terminated user path and resolve against
+ * cwd + chroot root.
  */
-int ir0_resolve_user_path(const char *user_path, char *resolved, size_t resolved_sz,
-                          const char *cwd);
+int ir0_resolve_user_path(const char *user_path, char *resolved,
+                          size_t resolved_sz, const char *cwd,
+                          const char *root);
 
 #endif /* _IR0_PATH_USER_H */

--- a/includes/ir0/process_domains.h
+++ b/includes/ir0/process_domains.h
@@ -49,7 +49,7 @@ int process_rel_init_child(struct process *child, const struct process *parent,
 int process_mm_cursor_clone(struct process *dst, const struct process *src);
 
 /*
- * Copy cwd / comm / rlimits (session-visible process attributes).
+ * Copy cwd / root (chroot) / comm / rlimits (session-visible process attributes).
  * May not sleep. Returns 0 or -errno.
  */
 int process_session_attrs_clone(struct process *dst, const struct process *src);

--- a/includes/ir0/syscall.h
+++ b/includes/ir0/syscall.h
@@ -68,6 +68,7 @@
 #define SYS_KILL         __NR_kill
 #define SYS_GETCWD       __NR_getcwd
 #define SYS_CHDIR        __NR_chdir
+#define SYS_CHROOT       __NR_chroot
 #define SYS_MKDIR        __NR_mkdir
 #define SYS_RMDIR        __NR_rmdir
 #define SYS_LINK         __NR_link
@@ -308,6 +309,11 @@ static inline int64_t ir0_getcwd(char *buf, size_t size)
 static inline int64_t ir0_chdir(const char *path)
 {
     return syscall1(SYS_CHDIR, (int64_t)path);
+}
+
+static inline int64_t ir0_chroot(const char *path)
+{
+    return syscall1(SYS_CHROOT, (int64_t)path);
 }
 
 /* Filesystem operations */

--- a/includes/uapi/ir0/syscall_linux.h
+++ b/includes/uapi/ir0/syscall_linux.h
@@ -98,6 +98,7 @@
 #define __NR_getcwd        79
 #define __NR_chdir         80
 #define __NR_fchdir        81
+#define __NR_chroot       161
 #define __NR_rename        82
 #define __NR_mkdir         83
 #define __NR_rmdir         84

--- a/interrupt/arch/isr_handlers.c
+++ b/interrupt/arch/isr_handlers.c
@@ -20,6 +20,7 @@
 #include <ir0/ktm/klog.h>
 #include <ir0/debug_trap.h>
 #include <kernel/process.h>
+#include <ir0/sched.h>
 #include <config.h>
 #include <ir0/input_backend.h>
 #include <string.h>
@@ -222,33 +223,43 @@ void isr_handler64(uint64_t interrupt_number, uint64_t *stack)
         klog_debug_fmt("ISR", "[ISR] int=%llx current=%llx cr3=%llx rip=%llx cs=%llx rsp=%llx ss=%llx frame=%llx user=%llx", (unsigned long long)(interrupt_number), (unsigned long long)((uint64_t)(uintptr_t)current), (unsigned long long)(get_current_page_directory()), (unsigned long long)(fault_rip), (unsigned long long)(fault_cs), (unsigned long long)(fault_rsp), (unsigned long long)(stack[6]), (unsigned long long)((uint64_t)(uintptr_t)stack), (unsigned long long)(user));
 
         /*
-         * Desk-session flake: #UD/#GP with RIP on BSS globals
-         * (current_process @ .bss). Dump the fault RSP window to catch the
-         * call/ret that landed in data.
+         * Desk-session flake: #UD/#GP with RIP in non-text (data/bss).
+         * Fault RIP 0x20E52A was nearest-symbol noise on event_queue; class
+         * is KERNEL_EXECUTE_BSS for any RIP past _etext.
          */
-        if (!user && fault_rip >= (uint64_t)(uintptr_t)&current_process &&
-            fault_rip < (uint64_t)(uintptr_t)&current_process + 0x1000ULL)
-        {
-            char rspbuf[512];
-            size_t off;
-            size_t i;
+	{
+		extern char _etext[];
+		extern char _end[];
+		uint64_t et = (uint64_t)(uintptr_t)_etext;
+		uint64_t en = (uint64_t)(uintptr_t)_end;
 
-            klog_debug_fmt("ISR", "CLASSIFY KERNEL_EXECUTE_BSS rip_near=current_process "
-                           "bss_x &current_process=%llx *current_process=%llx "
-                           "rsp_qwords=",
-                           (unsigned long long)((uint64_t)(uintptr_t)&current_process),
-                           (unsigned long long)((uint64_t)(uintptr_t)current_process));
-            off = 0;
-            for (i = 0; i < 24 && off < sizeof(rspbuf) - 24; i++)
-            {
-                uint64_t v = ((uint64_t *)(uintptr_t)fault_rsp)[i];
+		if (!user && fault_rip >= et && fault_rip < en)
+		{
+			char rspbuf[512];
+			size_t off;
+			size_t i;
 
-                off += (size_t)snprintf(rspbuf + off, sizeof(rspbuf) - off,
-                                        "%s%llx", i ? " " : "",
-                                        (unsigned long long)v);
-            }
-            klog_debug("ISR", rspbuf);
-        }
+			klog_notice_fmt("ISR",
+					"CLASSIFY KERNEL_EXECUTE_BSS rip=%llx "
+					"_etext=%llx _end=%llx current=%llx "
+					"comm=%s rsp_qwords=",
+					(unsigned long long)fault_rip,
+					(unsigned long long)et,
+					(unsigned long long)en,
+					(unsigned long long)((uint64_t)(uintptr_t)current),
+					current ? current->comm : "(none)");
+			off = 0;
+			for (i = 0; i < 24 && off < sizeof(rspbuf) - 24; i++)
+			{
+				uint64_t v = ((uint64_t *)(uintptr_t)fault_rsp)[i];
+
+				off += (size_t)snprintf(rspbuf + off, sizeof(rspbuf) - off,
+							"%s%llx", i ? " " : "",
+							(unsigned long long)v);
+			}
+			klog_notice("ISR", rspbuf);
+		}
+	}
     }
 
     /* Manejar excepciones del CPU (0-31) */
@@ -381,6 +392,11 @@ void isr_handler64(uint64_t interrupt_number, uint64_t *stack)
 
         /* Enviar EOI para IRQs */
         pic_send_eoi64(irq);
+	/*
+	 * Safe preempt after wake (TTY/timer flags). Must run with the IRQ
+	 * frame still intact; never schedule from keyboard_handler itself.
+	 */
+	(void)sched_irq_preempt_from_frame(stack);
         return;
     }
 

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -176,8 +176,10 @@ typedef struct process
 	uint64_t start_ticks;
 	struct robust_list_head *robust_list;
 	
-	/* Current working directory */
+	/* Current working directory (host-absolute). */
 	char cwd[256];
+	/* chroot(2) root (host-absolute); "/" = no jail. Inherited on fork. */
+	char root[256];
 	
 	/* Process command name (for ps) */
 	char comm[16]; /* Process command name (max 15 chars + null) */

--- a/kernel/process/create.c
+++ b/kernel/process/create.c
@@ -162,6 +162,8 @@ pid_t spawn(void (*entry)(void), const char *name, process_mode_t mode)
 		proc->umask = current_process->umask;
 		strncpy(proc->cwd, current_process->cwd, sizeof(proc->cwd) - 1);
 		proc->cwd[sizeof(proc->cwd) - 1] = '\0';
+		strncpy(proc->root, current_process->root, sizeof(proc->root) - 1);
+		proc->root[sizeof(proc->root) - 1] = '\0';
 	} else {
 		proc->uid = ROOT_UID;
 		proc->gid = ROOT_GID;
@@ -174,12 +176,19 @@ pid_t spawn(void (*entry)(void), const char *name, process_mode_t mode)
 		proc->umask = DEFAULT_UMASK;
 		strncpy(proc->cwd, "/", sizeof(proc->cwd) - 1);
 		proc->cwd[sizeof(proc->cwd) - 1] = '\0';
+		strncpy(proc->root, "/", sizeof(proc->root) - 1);
+		proc->root[sizeof(proc->root) - 1] = '\0';
 	}
 	process_cred_init_groups(proc);
 	if (proc->cwd[0] != '/')
 	{
 		strncpy(proc->cwd, "/", sizeof(proc->cwd) - 1);
 		proc->cwd[sizeof(proc->cwd) - 1] = '\0';
+	}
+	if (proc->root[0] != '/')
+	{
+		strncpy(proc->root, "/", sizeof(proc->root) - 1);
+		proc->root[sizeof(proc->root) - 1] = '\0';
 	}
 	
 	/* Set command name */

--- a/kernel/process/domains.c
+++ b/kernel/process/domains.c
@@ -91,6 +91,7 @@ int process_session_attrs_clone(process_t *dst, const process_t *src)
 		return -EINVAL;
 
 	memcpy(dst->cwd, src->cwd, sizeof(dst->cwd));
+	memcpy(dst->root, src->root, sizeof(dst->root));
 	memcpy(dst->comm, src->comm, sizeof(dst->comm));
 	memcpy(dst->rlimits, src->rlimits, sizeof(dst->rlimits));
 	dst->robust_list = src->robust_list;

--- a/kernel/syscalls.c
+++ b/kernel/syscalls.c
@@ -18,6 +18,7 @@
 #include <ir0/input_backend.h>
 #include <ir0/process.h>
 #include <ir0/sched.h>
+#include <ir0/clock.h>
 #include <ir0/ktm/klog.h>
 
 #define MAX_STDIN_WAITERS 8
@@ -42,8 +43,16 @@ int64_t syscalls_read_stdio_stdin(void *buf, size_t count)
 
 void stdin_wake_check(void)
 {
-	if (stdin_wake_check_nosched())
-		sched_schedule_next();
+	if (!stdin_wake_check_nosched())
+		return;
+	/*
+	 * Never sched_schedule_next() from here: keyboard IRQ calls this while
+	 * current may be userspace or idle. Mid-IRQ switch_to saves [rsp] into
+	 * prev->task.rip (kernel C / stack junk) → later kernel_ret/#UD into
+	 * BSS (desk panic after top/TTY). Defer via resched flags; ISR exit
+	 * uses sched_irq_preempt_from_frame, idle_poll yields cooperatively.
+	 */
+	clock_request_sched_resched();
 }
 
 int stdin_wake_check_nosched(void)

--- a/kernel/syscalls.h
+++ b/kernel/syscalls.h
@@ -62,6 +62,7 @@ int64_t sys_mkdir(const char *pathname, mode_t mode);
 int64_t sys_rmdir(const char *pathname);
 int64_t sys_chdir(const char *pathname);
 int64_t sys_getcwd(char *buf, size_t size);
+int64_t sys_chroot(const char *path);
 int64_t sys_utimensat(int dirfd, const char *pathname,
                       const struct timespec *times, int flags);
 int64_t sys_unlink(const char *pathname);

--- a/kernel/syscalls/fs_path_syscalls.c
+++ b/kernel/syscalls/fs_path_syscalls.c
@@ -27,6 +27,7 @@
 #include <ir0/path_routed.h>
 #include <ir0/path_user.h>
 #include <ir0/permissions.h>
+#include <ir0/credentials.h>
 #include <ir0/ktm/klog.h>
 #include <ir0/stat.h>
 #include <ir0/utimens.h>
@@ -82,7 +83,7 @@ int64_t sys_mount(const char *dev, const char *mountpoint, const char *fstype,
 
   rc = ir0_resolve_user_path(mountpoint, mountpoint_resolved,
                              sizeof(mountpoint_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
   mount_path = mountpoint_resolved;
@@ -130,7 +131,7 @@ int64_t sys_mount(const char *dev, const char *mountpoint, const char *fstype,
   else
   {
     rc = ir0_resolve_kpath_at(IR0_AT_FDCWD, dev_copy, dev_resolved,
-                              sizeof(dev_resolved), current_process->cwd);
+                              sizeof(dev_resolved), current_process->cwd, current_process->root);
     if (rc != 0)
       return rc;
     dev_path = dev_resolved;
@@ -219,7 +220,7 @@ int64_t sys_umount(const char *target, int flags)
     return -EINVAL;
 
   rc = ir0_resolve_user_path(target, target_resolved, sizeof(target_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -259,7 +260,7 @@ int64_t sys_mkdir(const char *pathname, mode_t mode)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                            current_process->cwd);
+                            current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -271,25 +272,19 @@ int64_t sys_chmod(const char *path, mode_t mode)
   if (!current_process || !path)
     return -EFAULT;
 
-  /* Validate path is in userspace (for USER_MODE processes) */
+  /* Resolve relative paths against cwd; absolute under chroot. */
+  char resolved[256];
+  const char *path_to_use = path;
+  int rc;
+
   if (validate_userspace_string(path, 256) != 0)
     return -EFAULT;
 
-  /* Resolve relative paths against cwd */
-  char resolved[256];
-  const char *path_to_use = path;
-  if (!is_absolute_path(path))
-  {
-    if (join_paths(current_process->cwd, path, resolved, sizeof(resolved)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved;
-  }
-  else
-  {
-    if (normalize_path(path, resolved, sizeof(resolved)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved;
-  }
+  rc = ir0_resolve_user_path(path, resolved, sizeof(resolved),
+                             current_process->cwd, current_process->root);
+  if (rc != 0)
+    return rc;
+  path_to_use = resolved;
 
   stat_t st;
   int sret = vfs_stat(path_to_use, &st);
@@ -304,31 +299,23 @@ int64_t sys_chmod(const char *path, mode_t mode)
 
 int64_t sys_chown(const char *path, uid_t owner, gid_t group)
 {
+  char resolved[256];
+  int rc;
+
   if (!current_process || !path)
     return -EFAULT;
   if (validate_userspace_string(path, 256) != 0)
     return -EFAULT;
 
-  /* Resolve relative paths against cwd */
-  char resolved[256];
-  const char *path_to_use = path;
-  if (!is_absolute_path(path))
-  {
-    if (join_paths(current_process->cwd, path, resolved, sizeof(resolved)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved;
-  }
-  else
-  {
-    if (normalize_path(path, resolved, sizeof(resolved)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved;
-  }
+  rc = ir0_resolve_user_path(path, resolved, sizeof(resolved),
+                             current_process->cwd, current_process->root);
+  if (rc != 0)
+    return rc;
 
   if (current_process->euid != ROOT_UID)
     return -EPERM;
 
-  return vfs_chown(path_to_use, owner, group);
+  return vfs_chown(resolved, owner, group);
 }
 
 int64_t sys_link(const char *oldpath, const char *newpath)
@@ -346,12 +333,12 @@ int64_t sys_link(const char *oldpath, const char *newpath)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(oldpath, old_resolved, sizeof(old_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
   rc = ir0_resolve_user_path(newpath, new_resolved, sizeof(new_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -380,12 +367,12 @@ int64_t sys_rename(const char *oldpath, const char *newpath)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(oldpath, old_resolved, sizeof(old_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
   rc = ir0_resolve_user_path(newpath, new_resolved, sizeof(new_resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -433,7 +420,8 @@ int64_t sys_uname(struct utsname *buf)
  */
 int64_t sys_access(const char *pathname, int mode)
 {
-  int64_t rc;
+  char resolved[256];
+  int rc;
 
   if (!current_process || !pathname)
     return -EFAULT;
@@ -441,23 +429,14 @@ int64_t sys_access(const char *pathname, int mode)
   if (validate_userspace_string(pathname, 256) != 0)
     return -EFAULT;
 
-  char resolved[256];
-  const char *path_to_use = pathname;
-  if (!is_absolute_path(pathname))
-  {
-    if (join_paths(current_process->cwd, pathname, resolved, sizeof(resolved)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved;
-  }
-  else if (normalize_path(pathname, resolved, sizeof(resolved)) == 0)
-  {
-    path_to_use = resolved;
-  }
+  rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
+                             current_process->cwd, current_process->root);
+  if (rc != 0)
+    return rc;
 
-  rc = ir0_access_path_routed(path_to_use, mode,
-                              (uid_t)current_process->euid,
-                              (gid_t)current_process->egid);
-  return rc;
+  return ir0_access_path_routed(resolved, mode,
+                                (uid_t)current_process->euid,
+                                (gid_t)current_process->egid);
 }
 
 int64_t sys_faccessat(int dirfd, const char *pathname, int mode, int flags)
@@ -509,7 +488,7 @@ int64_t sys_rmdir(const char *pathname)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                            current_process->cwd);
+                            current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -530,6 +509,10 @@ int64_t ir0_chdir_resolved(const char *pathname)
   if (len == 0 || len >= 256)
     return -EINVAL;
 
+  /*
+   * pathname is a kernel/host path (already chroot-mapped by sys_chdir,
+   * or an open directory path from fchdir).
+   */
   if (is_absolute_path(pathname))
   {
     if (normalize_path(pathname, new_path, sizeof(new_path)) != 0)
@@ -563,18 +546,26 @@ int64_t ir0_chdir_resolved(const char *pathname)
 
 int64_t sys_chdir(const char *pathname)
 {
+  char resolved[256];
+  int rc;
+
   if (!current_process || !pathname)
     return -EFAULT;
 
-  /* Validate pathname is in userspace (for USER_MODE processes) */
   if (validate_userspace_string(pathname, 256) != 0)
     return -EFAULT;
 
-  return ir0_chdir_resolved(pathname);
+  rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
+                             current_process->cwd, current_process->root);
+  if (rc != 0)
+    return rc;
+
+  return ir0_chdir_resolved(resolved);
 }
 
 int64_t sys_getcwd(char *buf, size_t size)
 {
+  char visible[256];
   size_t len;
 
   if (!current_process || !buf || size == 0)
@@ -584,15 +575,59 @@ int64_t sys_getcwd(char *buf, size_t size)
     return -EFAULT;
 
   process_cwd_ensure_absolute(current_process);
+  if (current_process->root[0] != '/')
+  {
+    strncpy(current_process->root, "/", sizeof(current_process->root) - 1);
+    current_process->root[sizeof(current_process->root) - 1] = '\0';
+  }
 
-  len = strlen(current_process->cwd);
+  if (ir0_path_getcwd_visible(current_process->root, current_process->cwd,
+                              visible, sizeof(visible)) != 0)
+    return -ENAMETOOLONG;
+
+  len = strlen(visible);
   if (len >= size)
     return -ERANGE;
 
-  if (copy_to_user(buf, current_process->cwd, len + 1) != 0)
+  if (copy_to_user(buf, visible, len + 1) != 0)
     return -EFAULT;
 
   return (int64_t)len;
+}
+
+int64_t sys_chroot(const char *path)
+{
+  char resolved[256];
+  stat_t st;
+  int rc;
+  int64_t ret;
+
+  if (!current_process || !path)
+    return -EFAULT;
+
+  if (!ir0_cred_is_root())
+    return -EPERM;
+
+  if (validate_userspace_string(path, 256) != 0)
+    return -EFAULT;
+
+  rc = ir0_resolve_user_path(path, resolved, sizeof(resolved),
+                             current_process->cwd, current_process->root);
+  if (rc != 0)
+    return rc;
+
+  ret = ir0_stat_path_routed(resolved, &st);
+  if (ret < 0)
+    return ret;
+  if (!S_ISDIR(st.st_mode))
+    return -ENOTDIR;
+
+  /*
+   * Linux: does not change cwd. Absolute paths after this use the new root.
+   */
+  strncpy(current_process->root, resolved, sizeof(current_process->root) - 1);
+  current_process->root[sizeof(current_process->root) - 1] = '\0';
+  return 0;
 }
 
 int64_t sys_utimensat(int dirfd, const char *pathname,
@@ -631,7 +666,7 @@ int64_t sys_utimensat(int dirfd, const char *pathname,
       return -EFAULT;
 
     rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                              current_process->cwd);
+                              current_process->cwd, current_process->root);
     if (rc != 0)
       return rc;
   }
@@ -660,7 +695,7 @@ int64_t sys_unlink(const char *pathname)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                            current_process->cwd);
+                            current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -684,7 +719,7 @@ int64_t sys_truncate(const char *pathname, off_t length)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                            current_process->cwd);
+                            current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -748,7 +783,7 @@ int64_t sys_statfs(const char *pathname, void *buf)
 		return -EFAULT;
 
 	rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-				   current_process->cwd);
+				   current_process->cwd, current_process->root);
 	if (rc != 0)
 		return rc;
 

--- a/kernel/syscalls/fs_path_syscalls.h
+++ b/kernel/syscalls/fs_path_syscalls.h
@@ -37,6 +37,7 @@ int64_t sys_chdir(const char *pathname);
  */
 int64_t ir0_chdir_resolved(const char *pathname);
 int64_t sys_getcwd(char *buf, size_t size);
+int64_t sys_chroot(const char *path);
 int64_t sys_utimensat(int dirfd, const char *pathname,
                       const struct timespec *times, int flags);
 int64_t sys_unlink(const char *pathname);

--- a/kernel/syscalls/fs_syscalls.c
+++ b/kernel/syscalls/fs_syscalls.c
@@ -182,7 +182,7 @@ int ir0_resolve_path_at(int dirfd, const char *user_path, char *resolved,
   if (path_copy[0] == '/')
   {
     return ir0_resolve_kpath_at(IR0_AT_FDCWD, path_copy, resolved, resolved_sz,
-                                current_process->cwd);
+                                current_process->cwd, current_process->root);
   }
 
   if (dirfd != IR0_AT_FDCWD)
@@ -192,12 +192,17 @@ int ir0_resolve_path_at(int dirfd, const char *user_path, char *resolved,
       return rc;
     if (join_paths(dirpath, path_copy, joined, sizeof(joined)) != 0)
       return -ENAMETOOLONG;
-    return ir0_resolve_kpath_at(IR0_AT_FDCWD, joined, resolved, resolved_sz,
-                                current_process->cwd);
+    /*
+     * dirfd path is already host-absolute (may be outside the jail).
+     * Do not re-apply process root (Linux openat via outside fd).
+     */
+    if (normalize_path(joined, resolved, resolved_sz) != 0)
+      return -ENAMETOOLONG;
+    return 0;
   }
 
   return ir0_resolve_user_path_at(dirfd, user_path, resolved, resolved_sz,
-                                  current_process->cwd);
+                                  current_process->cwd, current_process->root);
 }
 
 static int64_t do_readlinkat(int dirfd, const char *pathname, char *buf,
@@ -1482,7 +1487,7 @@ int64_t sys_open(const char *pathname, int flags, mode_t mode)
 
 
   path_rc = ir0_resolve_kpath_at(IR0_AT_FDCWD, path_copy, resolved_path,
-                                 sizeof(resolved_path), current_process->cwd);
+                                 sizeof(resolved_path), current_process->cwd, current_process->root);
   if (path_rc != 0)
     return path_rc;
 
@@ -1503,7 +1508,7 @@ int64_t sys_stat(const char *pathname, stat_t *buf)
     return -EFAULT;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 
@@ -1738,7 +1743,7 @@ int64_t sys_mknod(const char *pathname, unsigned int mode, unsigned int dev)
     return -EINVAL;
 
   rc = ir0_resolve_user_path(pathname, resolved, sizeof(resolved),
-                             current_process->cwd);
+                             current_process->cwd, current_process->root);
   if (rc != 0)
     return rc;
 

--- a/kernel/syscalls/process_syscalls.c
+++ b/kernel/syscalls/process_syscalls.c
@@ -32,6 +32,7 @@
 #include <ir0/kernel.h>
 #include <ir0/elf_loader.h>
 #include <ir0/path.h>
+#include <ir0/path_user.h>
 #include <ir0/permissions.h>
 #include <ir0/ktm/klog.h>
 #include <ir0/kmem.h>
@@ -949,21 +950,16 @@ int64_t sys_exec(const char *pathname,
   if (validate_userspace_string(pathname, 256) != 0)
     return -EFAULT;
 
-  /* Unix-style: resolve relative paths against cwd before loading */
+  /* Unix-style: resolve relative against cwd; absolute under chroot. */
   char resolved_path[256];
   const char *path_to_use = pathname;
-  if (!is_absolute_path(pathname))
-  {
-    if (join_paths(current_process->cwd, pathname, resolved_path, sizeof(resolved_path)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved_path;
-  }
-  else
-  {
-    if (normalize_path(pathname, resolved_path, sizeof(resolved_path)) != 0)
-      return -ENAMETOOLONG;
-    path_to_use = resolved_path;
-  }
+  int path_rc;
+
+  path_rc = ir0_resolve_user_path(pathname, resolved_path, sizeof(resolved_path),
+                                  current_process->cwd, current_process->root);
+  if (path_rc != 0)
+    return path_rc;
+  path_to_use = resolved_path;
 
   /* argv/envp are NULL-terminated vectors; only validate the first slot here.
    * Per-entry mapped checks happen inside the iteration below.

--- a/kernel/syscalls/syscall_dispatch.c
+++ b/kernel/syscalls/syscall_dispatch.c
@@ -147,6 +147,7 @@ WRAP4(sys_faccessat, int, const char *, int, int)
 WRAP1(sys_dup, int)
 WRAP3(sys_exec, const char *, char *const *, char *const *)
 WRAP1(sys_chdir, const char *)
+WRAP1(sys_chroot, const char *)
 WRAP1(sys_fchdir, int)
 WRAP5(sys_mount, const char *, const char *, const char *, unsigned long,
       const void *)
@@ -355,6 +356,7 @@ void syscall_table_init(void)
   syscall_table_rw[__NR_getcwd]         = wrap_sys_getcwd;
   syscall_table_rw[__NR_utimensat]      = wrap_sys_utimensat;
   syscall_table_rw[__NR_chdir]          = wrap_sys_chdir;
+  syscall_table_rw[__NR_chroot]         = wrap_sys_chroot;
   syscall_table_rw[__NR_fchdir]         = wrap_sys_fchdir;
   syscall_table_rw[__NR_mkdir]          = wrap_sys_mkdir;
   syscall_table_rw[__NR_rmdir]          = wrap_sys_rmdir;

--- a/sched/sched_resched.c
+++ b/sched/sched_resched.c
@@ -41,6 +41,13 @@ static int sched_irq_may_preempt(uint64_t *gpr_stack)
 		return 2;
 
 	/*
+	 * Keyboard/stdin wake sets clock_request_sched_resched without always
+	 * arming tty_need_resched (stdin_waiters-only). Honor it on any IRQ.
+	 */
+	if (clock_sched_resched_pending_peek() && sched_count_runnable() > 1)
+		return 4;
+
+	/*
 	 * Brief PIT fairness window after TTY wake (see ir0_console_note_tty_wake).
 	 * Avoids global timer preempt during PID1 fork/exec boot.
 	 */
@@ -114,11 +121,13 @@ int sched_irq_preempt_from_frame(uint64_t *gpr_stack)
 
 		(void)ir0_console_take_resched();
 		KTM_EVENT(KTM_EV_SCHED_IRQ_TTY_PREEMPT);
+		/*
+		 * Ring-0 interrupt context (idle / kernel): never schedule here.
+		 * Mid-ISR switch_to corrupts prev RIP/RSP → #UD into BSS on resume.
+		 * Wake left tasks READY; idle_poll / cooperative yield picks them up.
+		 */
 		if ((gpr_stack[18] & 3U) != 3U)
-		{
-			sched_schedule_next();
 			return 0;
-		}
 		if (sched_count_runnable() <= 1)
 			return 0;
 		process_save_user_context_from_irq_frame(gpr_stack);
@@ -136,6 +145,8 @@ int sched_irq_preempt_from_frame(uint64_t *gpr_stack)
 
 	if (why == 3)
 		KTM_EVENT(KTM_EV_SCHED_IRQ_TIMER_PREEMPT);
+	if (why == 4)
+		(void)clock_take_sched_resched_pending();
 
 	process_save_user_context_from_irq_frame(gpr_stack);
 	sched_context_switch_skip_prev_save();

--- a/scripts/inject_init_minix.py
+++ b/scripts/inject_init_minix.py
@@ -145,7 +145,11 @@ def inode_type(mode):
 
 
 def collect_zones_from_inode(f, inode):
-    """Return all data zone numbers referenced by an inode."""
+    """
+    Return every zone owned by an inode: data + single/double-indirect
+    pointer blocks. sync_zmap must mark metadata zones allocated; omitting
+    them frees indirect blocks and the next inject overwrites them (init SEGV).
+    """
     zones = set()
     if (inode["mode"] & IFMT) != IFDIR and (inode["mode"] & IFMT) != IFREG:
         return zones
@@ -156,18 +160,23 @@ def collect_zones_from_inode(f, inode):
         if z:
             zones.add(z)
     if inode["zones"][7]:
-        ind = read_block(f, inode["zones"][7])
+        ind_z = inode["zones"][7]
+        zones.add(ind_z)
+        ind = read_block(f, ind_z)
         for j in range(BLOCK // 2):
             z, = struct.unpack("<H", ind[j * 2 : j * 2 + 2])
             if z == 0:
                 break
             zones.add(z)
     if inode["zones"][8]:
-        dind = read_block(f, inode["zones"][8])
+        dind_z = inode["zones"][8]
+        zones.add(dind_z)
+        dind = read_block(f, dind_z)
         for j in range(BLOCK // 2):
             z1, = struct.unpack("<H", dind[j * 2 : j * 2 + 2])
             if z1 == 0:
                 break
+            zones.add(z1)
             lvl1 = read_block(f, z1)
             for k in range(BLOCK // 2):
                 z2, = struct.unpack("<H", lvl1[k * 2 : k * 2 + 2])
@@ -214,7 +223,7 @@ def sync_imap_from_tree(f, sb):
 
 
 def sync_zmap_from_inodes(f, sb, used_inodes=None):
-    """Mark data zones referenced by used inodes as allocated (bit clear = used)."""
+    """Rebuild zmap from inodes (bit set = free, clear = allocated)."""
     if used_inodes is None:
         used_inodes = collect_used_inodes(f, sb)
     used_zones = set()
@@ -222,8 +231,10 @@ def sync_zmap_from_inodes(f, sb, used_inodes=None):
         inode = read_inode(f, sb, n)
         used_zones.update(collect_zones_from_inode(f, inode))
     zmap_blk_base = zmap_start(sb)
+    for blk in range(sb["zmap_blocks"]):
+        write_block(f, zmap_blk_base + blk, bytes(b"\xff" * BLOCK))
     for zone in used_zones:
-        if zone < sb["firstdatazone"]:
+        if zone < sb["firstdatazone"] or zone >= sb["nzones"]:
             continue
         idx = zone - sb["firstdatazone"]
         byte_i = idx // 8
@@ -241,16 +252,18 @@ def sync_bitmaps_from_tree(f, sb):
     return used
 
 
+# Sequential hint: avoid rescanning the whole zmap from firstdatazone each time.
+_zone_alloc_hint = 0
+
+
 def alloc_inode(f, sb):
-    sync_imap_from_tree(f, sb)
-    imap = read_block(f, imap_block(sb))
-    for n in range(1, sb["ninodes"] + 1):
+    """Allocate from imap; caller must have a coherent map (format or sync)."""
+    imap = bytearray(read_block(f, imap_block(sb)))
+    limit = min(sb["ninodes"] + 1, BLOCK * 8)
+    for n in range(1, limit):
         byte_i = n // 8
         bit_i = n % 8
-        if byte_i >= BLOCK:
-            break
         if (imap[byte_i] & (1 << bit_i)) == 0:
-            imap = bytearray(imap)
             imap[byte_i] |= 1 << bit_i
             write_block(f, imap_block(sb), bytes(imap))
             return n
@@ -258,33 +271,60 @@ def alloc_inode(f, sb):
 
 
 def zone_free(f, sb, zone):
-    if zone < sb["firstdatazone"]:
+    if zone < sb["firstdatazone"] or zone >= sb["nzones"]:
         return False
     idx = zone - sb["firstdatazone"]
     byte_i = idx // 8
     bit_i = idx % 8
     zmap_blk = zmap_start(sb) + byte_i // BLOCK
     zoff = byte_i % BLOCK
-    zmap = bytearray(read_block(f, zmap_blk))
+    zmap = read_block(f, zmap_blk)
     return (zmap[zoff] & (1 << bit_i)) != 0
 
 
 def alloc_zone(f, sb):
-    sync_zmap_from_inodes(f, sb)
+    """
+    Allocate one data zone from the on-disk zmap.
+
+    Do NOT rebuild zmap here: pack-minix calls this per block of every file.
+    With nzones=65535, sync-per-alloc made desktop inject appear hung.
+    """
+    global _zone_alloc_hint
     zmap_blk_base = zmap_start(sb)
-    for zone in range(sb["firstdatazone"], sb["nzones"]):
-        if not zone_free(f, sb, zone):
-            continue
-        idx = zone - sb["firstdatazone"]
-        byte_i = idx // 8
-        bit_i = idx % 8
-        zmap_blk = zmap_blk_base + byte_i // BLOCK
-        zoff = byte_i % BLOCK
-        zmap = bytearray(read_block(f, zmap_blk))
-        zmap[zoff] &= ~(1 << bit_i)
-        write_block(f, zmap_blk, bytes(zmap))
-        return zone
-    raise SystemExit("no free zone")
+    first = sb["firstdatazone"]
+    nzones = sb["nzones"]
+    hint = _zone_alloc_hint if _zone_alloc_hint >= first else first
+
+    def try_from(start_zone):
+        idx0 = start_zone - first
+        start_blk = idx0 // (BLOCK * 8)
+        for zmap_i in range(start_blk, sb["zmap_blocks"]):
+            zmap = bytearray(read_block(f, zmap_blk_base + zmap_i))
+            bit_base = zmap_i * BLOCK * 8
+            off0 = 0 if zmap_i > start_blk else (idx0 % (BLOCK * 8)) // 8
+            for zoff in range(off0, BLOCK):
+                byte_val = zmap[zoff]
+                if byte_val == 0:
+                    continue
+                bit0 = 0 if not (zmap_i == start_blk and zoff == off0) else (idx0 % 8)
+                for bit_i in range(bit0, 8):
+                    if (byte_val & (1 << bit_i)) == 0:
+                        continue
+                    zone = first + bit_base + zoff * 8 + bit_i
+                    if zone < first or zone >= nzones:
+                        continue
+                    zmap[zoff] &= ~(1 << bit_i)
+                    write_block(f, zmap_blk_base + zmap_i, bytes(zmap))
+                    return zone
+        return None
+
+    zone = try_from(hint)
+    if zone is None and hint > first:
+        zone = try_from(first)
+    if zone is None:
+        raise SystemExit("no free zone")
+    _zone_alloc_hint = zone + 1
+    return zone
 
 
 def dir_zone_list(inode):
@@ -457,6 +497,8 @@ def format_minix_v1(f, ninodes=64, nzones=1024):
         f"MINIX_FORMAT ok magic=0x{MAGIC:04x} ninodes={sb['ninodes']} "
         f"nzones={sb['nzones']} firstdatazone={sb['firstdatazone']}"
     )
+    global _zone_alloc_hint
+    _zone_alloc_hint = sb["firstdatazone"]
     return sb
 
 
@@ -913,9 +955,9 @@ def main():
 
     with open(disk_path, "r+b") as f:
         sb = parse_super(read_block(f, 1))
+        # One rebuild per inject process; alloc_* maintain bitmaps afterward.
         sync_bitmaps_from_tree(f, sb)
         write_file(f, sb, path_parts, data, file_path, file_mode, owner)
-        sync_bitmaps_from_tree(f, sb)
 
     dest_display = "/" + "/".join(path_parts)
     verify_script = os.path.join(os.path.dirname(__file__), "verify_minix_rootfs.py")

--- a/scripts/smoke_desktop_cmd_matrix.py
+++ b/scripts/smoke_desktop_cmd_matrix.py
@@ -12,6 +12,8 @@ Stability notes:
   - Empty-prompt storms abort the batch so a fresh VM can retry.
   - Poweroff is soft-gated (TIMEOUT → WARN, round still PASS if ash OK).
   - Doom is opt-in (--with-doom / --only-doom).
+  - --stability: product binaries that stress TTY/sched/exec (top/man/tcc/pipes);
+    optional doom; fail hard on panic/#UD/SEGV tags.
 """
 
 from __future__ import annotations
@@ -50,6 +52,16 @@ SPECIAL = {
     "?": "shift-slash",
     "(": "shift-9",
     ")": "shift-0",
+    ",": "comma",
+    "+": "shift-equal",
+    "*": "shift-8",
+    ">": "shift-dot",
+    "<": "shift-comma",
+    "#": "shift-3",
+    "{": "shift-bracket_left",
+    "}": "shift-bracket_right",
+    "[": "bracket_left",
+    "]": "bracket_right",
 }
 
 FAIL_RES = [
@@ -59,6 +71,7 @@ FAIL_RES = [
     re.compile(r"Unhandled kernel"),
     re.compile(r"General protection fault"),
     re.compile(r"#UD\b|#DF\b"),
+    re.compile(r"CONSOLE_SESSION_SEGV"),
     re.compile(r"shshsh|busyboxbusybox"),
 ]
 LOCK_SPAM_RE = re.compile(r"unable to lock supervise/lock")
@@ -226,6 +239,107 @@ CASES: list[Case] = [
 ]
 
 
+# Product-binaries stress suite: exit fullscreen apps, pipes, tcc/exec, find.
+# Doom is attached separately via --with-doom (needs WAD).
+#
+# BusyBox top: without CONFIG_FEATURE_TOP_INTERACTIVE, `q` is ignored and top
+# loops until signal. Use batch mode (-b -n N) for a reliable leave→prompt
+# path; top_intr soft-gates Ctrl-C until TTY SIGINT is solid.
+STABILITY_CASES: list[Case] = [
+    Case("true", "true", expect_prompt, echo="true"),
+    Case(
+        "top_batch",
+        "top -b -n 2;echo TOP_BATCH_OK",
+        expect_prompt_any("TOP_BATCH_OK", "Mem:"),
+        echo="TOP_BATCH_OK",
+        timeout=45.0,
+    ),
+    Case(
+        "top_leave",
+        "top -b -n 3;echo TOP_LEAVE_OK",
+        expect_prompt_any("TOP_LEAVE_OK"),
+        echo="TOP_LEAVE_OK",
+        timeout=55.0,
+    ),
+    Case(
+        "top_intr",
+        "",
+        expect_prompt_any("TOP_INTR_OK"),
+        special="top_intr",
+        echo="TOP_INTR_OK",
+        timeout=55.0,
+    ),
+    Case(
+        "man_quit",
+        "",
+        expect_prompt_any("MAN_QUIT_OK"),
+        special="man_quit",
+        echo="MAN_QUIT_OK",
+        timeout=55.0,
+    ),
+    Case(
+        "find_etc",
+        "find /etc -name hostname;echo FIND_OK",
+        expect_prompt_any("FIND_OK"),
+        echo="FIND_OK",
+        timeout=35.0,
+    ),
+    Case(
+        "dmesg_file",
+        "dmesg>/tmp/d.txt;wc -c /tmp/d.txt;echo DMESG_FILE_OK",
+        expect_prompt_any("DMESG_FILE_OK"),
+        echo="DMESG_FILE_OK",
+        timeout=45.0,
+    ),
+    Case(
+        "dmesg_pipe",
+        "dmesg|grep -i irq;echo DMESG_PIPE_OK",
+        expect_prompt_any("DMESG_PIPE_OK"),
+        echo="DMESG_PIPE_OK",
+        timeout=50.0,
+    ),
+    Case(
+        "pipe_chain",
+        "echo a|cat|cat;echo PIPE_CHAIN_OK",
+        expect_prompt_any("PIPE_CHAIN_OK"),
+        echo="PIPE_CHAIN_OK",
+        timeout=30.0,
+    ),
+    Case(
+        "ls_proc_stat",
+        "cat /proc/stat;echo STAT_OK",
+        expect_prompt_any("STAT_OK", "cpu "),
+        echo="STAT_OK",
+        timeout=30.0,
+    ),
+]
+
+STABILITY_TCC_CASE = Case(
+    "tcc_hello",
+    "",
+    expect_prompt_any("TCC_HELLO", "TCC_HELLO_OK"),
+    special="tcc_mnt",
+    echo="TCC_HELLO_OK",
+    timeout=90.0,
+)
+
+
+HELLO_C = """\
+#include <stdio.h>
+int main(void)
+{
+    puts("TCC_HELLO");
+    return 0;
+}
+"""
+
+
+def stage_stability_share(share: Path) -> None:
+    share.mkdir(parents=True, exist_ok=True)
+    (share / "hello.c").write_text(HELLO_C)
+
+
+
 class Monitor:
     """Persistent QEMU HMP connection — critical for FEATURE_EDITING sendkey."""
 
@@ -390,6 +504,57 @@ def inject_case(mon: Monitor, case: Case, key_delay: float) -> None:
         mon.ret()
         time.sleep(2.0)
         mon.type_str("id", key_delay)
+        mon.ret()
+        return
+    if case.special == "top_intr":
+        d = max(key_delay, 0.40)
+        # Infinite batch refresh (no FEATURE_TOP_INTERACTIVE → `q` ignored).
+        mon.type_str("top -b -n 9999", d)
+        mon.ret()
+        time.sleep(2.5)
+        for _ in range(5):
+            mon.key("ctrl-c")
+            time.sleep(0.4)
+        time.sleep(1.2)
+        mon.type_str("echo TOP_INTR_OK", d)
+        mon.ret()
+        return
+    if case.special == "man_quit":
+        d = max(key_delay, 0.40)
+        mon.type_str("man true", d)
+        mon.ret()
+        time.sleep(2.5)
+        for _ in range(3):
+            mon.key("q")
+            time.sleep(0.35)
+        mon.key("ctrl-c")
+        time.sleep(1.0)
+        mon.type_str("echo MAN_QUIT_OK", d)
+        mon.ret()
+        return
+    if case.special == "tcc_mnt":
+        d = max(key_delay, 0.50)
+        mon.type_str("su", d)
+        mon.ret()
+        time.sleep(0.8)
+        mon.ret()
+        time.sleep(1.0)
+        mon.type_str("mkdir -p /mnt/host", d)
+        mon.ret()
+        time.sleep(1.0)
+        mon.type_str("busybox mount -t 9p ir0share /mnt/host", d)
+        mon.ret()
+        time.sleep(2.0)
+        mon.type_str("ls /mnt/host", d)
+        mon.ret()
+        time.sleep(1.0)
+        mon.type_str("tcc -o /tmp/hello /mnt/host/hello.c", d)
+        mon.ret()
+        time.sleep(3.0)
+        mon.type_str("/tmp/hello", d)
+        mon.ret()
+        time.sleep(1.5)
+        mon.type_str("echo TCC_HELLO_OK", d)
         mon.ret()
         return
     if case.special == "doom_mnt":
@@ -668,10 +833,21 @@ def run_cases(
 
         results.append((case.name, status))
         if status != "PASS":
-            # Soft cases: keep going so later cmds (soft_poweroff) still run.
-            if case.name in {"ctrl_c"} and (
+            # Soft cases: keep going so later cmds still run.
+            soft_continue = {"ctrl_c"}
+            if case.name in soft_continue and (
                 status == "TIMEOUT" or status.startswith("WARN:")
             ):
+                continue
+            # Stability soft-gates (no panic): do not abort the batch.
+            if case.name in {"top_intr", "man_quit", "dmesg_pipe"} and (
+                status == "TIMEOUT"
+                or status.startswith("WARN:")
+                or status.startswith("FAIL:enter_storm")
+            ):
+                # Relabel TIMEOUT as WARN so ash_results_ok treats it soft.
+                if status == "TIMEOUT":
+                    results[-1] = (case.name, "WARN:timeout")
                 continue
             return results
 
@@ -859,23 +1035,31 @@ def chunked(items: list[Case], size: int) -> list[list[Case]]:
     return [items[i : i + size] for i in range(0, len(items), size)]
 
 
-def ash_results_ok(results: list[tuple[str, str]]) -> bool:
+def ash_results_ok(
+    results: list[tuple[str, str]], *, stability: bool = False
+) -> bool:
     """Ash cases must PASS or soft WARN; hard FAIL fails the round."""
     soft_names = {"poweroff", "ctrl_c", "soft_poweroff"}
+    if stability:
+        # dmesg|grep flaky under HMP; top Ctrl-C soft until TTY SIGINT is solid.
+        soft_names |= {"dmesg_pipe", "top_intr", "man_quit"}
+    hard_in_status = ("panic", "#UD", "SEGV", "fatal", "DOUBLE", "ISR64", "Unhandled")
     for name, st in results:
         if st == "PASS" or st.startswith("WARN:"):
             continue
-        if name in soft_names and not st.startswith("FAIL:"):
+        if name in soft_names:
+            if any(tag in st for tag in hard_in_status):
+                return False
             continue
         return False
-    # Require a minimum core of PASS (not only WARNs).
-    core = {"true", "false", "echo_hi", "id", "whoami", "tab_etc"}
+    if stability:
+        core = {"true", "top_batch", "top_leave", "ls_proc_stat"}
+    else:
+        core = {"true", "false", "echo_hi", "id", "whoami", "tab_etc"}
     passed = {n for n, st in results if st == "PASS"}
-    # tab_etc may be in a later batch that did not run — only require present cores.
     present_core = core & {n for n, _ in results}
     if present_core and not present_core <= passed:
-        # allow tab_etc missing if batch aborted early
-        must = present_core - {"tab_etc"}
+        must = present_core - ({"tab_etc"} if not stability else set())
         if must and not must <= passed:
             return False
     return True
@@ -894,10 +1078,17 @@ def run_round(
     batch_size: int,
     only_doom: bool = False,
     skip_poweroff: bool = False,
+    stability: bool = False,
+    with_tcc: bool = True,
 ) -> tuple[bool, list[tuple[str, str]]]:
     results: list[tuple[str, str]] = []
     share_dir: Optional[Path] = None
-    batches = [] if only_doom else chunked(list(CASES), batch_size)
+    if only_doom:
+        batches: list[list[Case]] = []
+    elif stability:
+        batches = chunked(list(STABILITY_CASES), batch_size)
+    else:
+        batches = chunked(list(CASES), batch_size)
     doom_case: Optional[Case] = None
     if with_doom or only_doom:
         share_dir = Path(tempfile.mkdtemp(prefix="ir0-cmx-share."))
@@ -911,6 +1102,7 @@ def run_round(
             timeout=300.0,
         )
 
+    tcc_share: Optional[Path] = None
     try:
         log.write_text("")
         pending: list[Case] = []
@@ -933,11 +1125,10 @@ def run_round(
                 do_poweroff=False,
             )
             results.extend(part)
-            # If we soft-skipped enter_storm, queue remaining cases of this batch.
             if part and part[-1][1] == "WARN:enter_storm":
                 done = {n for n, _ in part}
                 pending = [c for c in work if c.name not in done]
-            if not ash_results_ok(part):
+            if not ash_results_ok(part, stability=stability):
                 return False, results
         if pending:
             print(f"  -- batch retry-pending ({len(pending)} cmds) --", flush=True)
@@ -953,7 +1144,26 @@ def run_round(
                 do_poweroff=False,
             )
             results.extend(part)
-            if not ash_results_ok(part):
+            if not ash_results_ok(part, stability=stability):
+                return False, results
+
+        if stability and with_tcc and not only_doom:
+            tcc_share = Path(tempfile.mkdtemp(prefix="ir0-cmx-tcc."))
+            stage_stability_share(tcc_share)
+            print("  -- batch tcc /mnt/host (su for mount) --", flush=True)
+            part = run_session(
+                iso,
+                disk_src,
+                port + 80,
+                log,
+                key_delay,
+                True,
+                [STABILITY_TCC_CASE],
+                share_dir=tcc_share,
+                do_poweroff=False,
+            )
+            results.extend(part)
+            if not ash_results_ok(part, stability=stability):
                 return False, results
 
         if doom_case is not None:
@@ -970,7 +1180,7 @@ def run_round(
                 do_poweroff=False,
             )
             results.extend(part)
-            if not ash_results_ok(part):
+            if not ash_results_ok(part, stability=stability):
                 return False, results
 
         if not skip_poweroff:
@@ -987,10 +1197,12 @@ def run_round(
                 do_poweroff=True,
             )
             results.extend(part)
-        return ash_results_ok(results), results
+        return ash_results_ok(results, stability=stability), results
     finally:
         if share_dir is not None:
             shutil.rmtree(share_dir, ignore_errors=True)
+        if tcc_share is not None:
+            shutil.rmtree(tcc_share, ignore_errors=True)
 
 
 def main() -> int:
@@ -1005,6 +1217,16 @@ def main() -> int:
     ap.add_argument("--su", action="store_true")
     ap.add_argument("--with-doom", action="store_true")
     ap.add_argument("--only-doom", action="store_true")
+    ap.add_argument(
+        "--stability",
+        action="store_true",
+        help="Run STABILITY_CASES (top/man/tcc/pipes) instead of ash matrix",
+    )
+    ap.add_argument(
+        "--no-tcc",
+        action="store_true",
+        help="With --stability, skip tcc hello via 9p",
+    )
     ap.add_argument(
         "--skip-poweroff",
         action="store_true",
@@ -1029,16 +1251,27 @@ def main() -> int:
         args.with_doom = True
     if args.with_doom:
         if not args.doom_bin.is_file() or not args.wad.is_file():
-            print("✗ missing doom bin or WAD", file=sys.stderr)
+            print(
+                f"✗ missing doom bin or WAD ({args.doom_bin}, {args.wad})",
+                file=sys.stderr,
+            )
             return 2
+    if args.stability:
+        args.skip_poweroff = True
+        if args.batch_size == 5:
+            args.batch_size = 3
 
-    ncases = (0 if args.only_doom else len(CASES)) + (
-        0 if args.skip_poweroff else 1
-    ) + (1 if args.with_doom else 0)
+    if args.stability:
+        ncases = len(STABILITY_CASES) + (0 if args.no_tcc else 1)
+    else:
+        ncases = 0 if args.only_doom else len(CASES)
+    ncases += 0 if args.skip_poweroff else 1
+    ncases += 1 if args.with_doom else 0
     print(
         f"CMD_MATRIX rounds={args.rounds} cases={ncases} "
         f"batch={args.batch_size} delay={args.key_delay} "
-        f"doom={args.with_doom} only_doom={args.only_doom}",
+        f"doom={args.with_doom} only_doom={args.only_doom} "
+        f"stability={args.stability}",
         flush=True,
     )
     round_ok = 0
@@ -1057,6 +1290,8 @@ def main() -> int:
             args.batch_size,
             only_doom=args.only_doom,
             skip_poweroff=args.skip_poweroff,
+            stability=args.stability,
+            with_tcc=not args.no_tcc,
         )
         for name, st in results:
             print(f"  {st:22} {name}", flush=True)

--- a/scripts/smoke_userspace_stability.py
+++ b/scripts/smoke_userspace_stability.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""
+Userspace stability harness (wrapper around smoke_desktop_cmd_matrix --stability).
+
+Exercises product binaries that previously exposed IRQ/sched/TTY instability:
+  top (batch + interactive quit), man quit, find, dmesg file/pipe, pipe chains,
+  /proc/stat, tcc compile+run via 9p. Optional --with-doom when WAD is present.
+
+Default disk: ISD development image (has top/man/tcc).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+ROOT = Path(__file__).resolve().parents[1]
+ISD = ROOT.parent / "ISD"
+MATRIX = ROOT / "scripts" / "smoke_desktop_cmd_matrix.py"
+
+DEFAULT_DISK = ISD / "out/x86_64/images/development/disk.img"
+DEFAULT_WADS = [
+    Path("/home/ivanr013/Escritorio/universal-doom/DOOM1.WAD"),
+    Path.home() / "Escritorio/universal-doom/DOOM1.WAD",
+    ROOT / "DOOM1.WAD",
+    ROOT / "doom1.wad",
+]
+
+
+def find_wad(explicit: Optional[Path]) -> Optional[Path]:
+    if explicit is not None and explicit.is_file():
+        return explicit
+    for p in DEFAULT_WADS:
+        if p.is_file():
+            return p
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iso", type=Path, default=ROOT / "kernel-x64-userspace.iso")
+    ap.add_argument("--disk", type=Path, default=DEFAULT_DISK)
+    ap.add_argument("--log", type=Path, default=Path("/tmp/ir0-userspace-stability.log"))
+    ap.add_argument("--rounds", type=int, default=1)
+    ap.add_argument("--port", type=int, default=46101)
+    ap.add_argument("--key-delay", type=float, default=0.40)
+    ap.add_argument("--batch-size", type=int, default=3)
+    ap.add_argument("--su", action="store_true")
+    ap.add_argument("--with-doom", action="store_true", help="Require doom WAD")
+    ap.add_argument(
+        "--auto-doom",
+        action="store_true",
+        help="Enable doom if a known WAD path exists (default for make target)",
+    )
+    ap.add_argument("--no-tcc", action="store_true")
+    ap.add_argument("--doom-bin", type=Path, default=ROOT / "setup/pid1/fase55e_doom_interactive")
+    ap.add_argument("--wad", type=Path, default=None)
+    args = ap.parse_args()
+
+    if not MATRIX.is_file():
+        print(f"✗ missing {MATRIX}", file=sys.stderr)
+        return 2
+    if not args.iso.is_file() or not args.disk.is_file():
+        print(f"✗ need iso+disk: {args.iso} {args.disk}", file=sys.stderr)
+        return 2
+
+    wad = find_wad(args.wad)
+    want_doom = args.with_doom or (args.auto_doom and wad is not None)
+    if args.with_doom and wad is None:
+        print("✗ --with-doom but no DOOM1.WAD found", file=sys.stderr)
+        return 2
+    if args.auto_doom and wad is None:
+        print("note: doom skipped (no DOOM1.WAD on host)", flush=True)
+
+    cmd = [
+        sys.executable,
+        str(MATRIX),
+        "--stability",
+        "--iso",
+        str(args.iso),
+        "--disk",
+        str(args.disk),
+        "--log",
+        str(args.log),
+        "--rounds",
+        str(args.rounds),
+        "--port",
+        str(args.port),
+        "--key-delay",
+        str(args.key_delay),
+        "--batch-size",
+        str(args.batch_size),
+        "--skip-poweroff",
+    ]
+    if args.su:
+        cmd.append("--su")
+    if args.no_tcc:
+        cmd.append("--no-tcc")
+    if want_doom and wad is not None:
+        cmd += ["--with-doom", "--doom-bin", str(args.doom_bin), "--wad", str(wad)]
+
+    print("USERSPACE_STABILITY:", " ".join(cmd), flush=True)
+    env = os.environ.copy()
+    return subprocess.call(cmd, cwd=str(ROOT), env=env)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_minix_rootfs.py
+++ b/scripts/verify_minix_rootfs.py
@@ -147,24 +147,42 @@ def read_file_prefix(f, sb, inode, length):
         return b""
     zones = inode["zones"]
     out = bytearray()
-    for zidx in range(9):
+
+    def take_zone(z):
+        nonlocal out
+        if len(out) >= size or z == 0:
+            return
+        chunk = read_block(f, z)
+        need = size - len(out)
+        out.extend(chunk[:need])
+
+    for zidx in range(7):
+        take_zone(zones[zidx])
         if len(out) >= size:
-            break
-        if zidx == 7 and zones[7]:
-            ind = read_block(f, zones[7])
-            for j in range((BLOCK // 2)):
-                z, = struct.unpack("<H", ind[j * 2 : j * 2 + 2])
-                if z == 0:
+            return bytes(out[:size])
+    if zones[7]:
+        ind = read_block(f, zones[7])
+        for j in range(BLOCK // 2):
+            z, = struct.unpack("<H", ind[j * 2 : j * 2 + 2])
+            if z == 0:
+                break
+            take_zone(z)
+            if len(out) >= size:
+                return bytes(out[:size])
+    if zones[8]:
+        dind = read_block(f, zones[8])
+        for j in range(BLOCK // 2):
+            z1, = struct.unpack("<H", dind[j * 2 : j * 2 + 2])
+            if z1 == 0:
+                break
+            lvl1 = read_block(f, z1)
+            for k in range(BLOCK // 2):
+                z2, = struct.unpack("<H", lvl1[k * 2 : k * 2 + 2])
+                if z2 == 0:
                     break
-                chunk = read_block(f, z)
-                need = size - len(out)
-                out.extend(chunk[:need])
+                take_zone(z2)
                 if len(out) >= size:
-                    break
-        elif zones[zidx]:
-            chunk = read_block(f, zones[zidx])
-            need = size - len(out)
-            out.extend(chunk[:need])
+                    return bytes(out[:size])
     return bytes(out[:size])
 
 

--- a/setup/pid1/chroot_smoke.c
+++ b/setup/pid1/chroot_smoke.c
@@ -1,0 +1,126 @@
+/* SPDX-License-Identifier: GPL-3.0-only */
+/*
+ * PID1 smoke: chroot(2) Linux-like root remap + fork inheritance.
+ *
+ * Tags (serial):
+ *   CHROOT_OK / CHROOT_FAIL
+ *   CHROOT_OPEN_INSIDE_OK
+ *   CHROOT_OUTSIDE_DENIED
+ *   CHROOT_GETCWD_OK
+ *   CHROOT_FORK_INHERIT_OK
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static void tag(const char *s)
+{
+	write(1, s, strlen(s));
+	write(1, "\n", 1);
+}
+
+static void fail(const char *why)
+{
+	tag("CHROOT_FAIL");
+	tag(why);
+	_exit(1);
+}
+
+static int write_file(const char *path, const char *data)
+{
+	int fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	ssize_t n;
+	size_t len;
+
+	if (fd < 0)
+		return -1;
+	len = strlen(data);
+	n = write(fd, data, len);
+	close(fd);
+	return (n == (ssize_t)len) ? 0 : -1;
+}
+
+static int file_starts_with(const char *path, const char *expect)
+{
+	char buf[64];
+	int fd = open(path, O_RDONLY);
+	ssize_t n;
+
+	if (fd < 0)
+		return 0;
+	n = read(fd, buf, sizeof(buf) - 1);
+	close(fd);
+	if (n <= 0)
+		return 0;
+	buf[n] = '\0';
+	return strncmp(buf, expect, strlen(expect)) == 0;
+}
+
+int main(void)
+{
+	char cwd[256];
+	pid_t pid;
+	int status = 0;
+	int fd;
+
+	if (mkdir("/jail", 0755) != 0 && errno != EEXIST)
+		fail("mkdir_jail");
+	if (write_file("/jail/inside.txt", "inside\n") != 0)
+		fail("write_inside");
+	if (write_file("/outside.txt", "outside\n") != 0)
+		fail("write_outside");
+
+	if (chroot("/jail") != 0)
+		fail("chroot_call");
+
+	if (!file_starts_with("/inside.txt", "inside"))
+		fail("open_inside");
+	tag("CHROOT_OPEN_INSIDE_OK");
+
+	fd = open("/outside.txt", O_RDONLY);
+	if (fd >= 0)
+	{
+		close(fd);
+		fail("outside_visible");
+	}
+	tag("CHROOT_OUTSIDE_DENIED");
+
+	if (chdir("/") != 0)
+		fail("chdir_root");
+	if (!getcwd(cwd, sizeof(cwd)))
+		fail("getcwd");
+	if (strcmp(cwd, "/") != 0)
+		fail("getcwd_value");
+	tag("CHROOT_GETCWD_OK");
+
+	pid = fork();
+	if (pid < 0)
+		fail("fork");
+	if (pid == 0)
+	{
+		if (!file_starts_with("/inside.txt", "inside"))
+			_exit(11);
+		fd = open("/outside.txt", O_RDONLY);
+		if (fd >= 0)
+		{
+			close(fd);
+			_exit(12);
+		}
+		_exit(0);
+	}
+	if (waitpid(pid, &status, 0) < 0)
+		fail("wait");
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+		fail("child");
+	tag("CHROOT_FORK_INHERIT_OK");
+
+	tag("CHROOT_OK");
+	for (;;)
+		pause();
+	return 0;
+}

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -22,6 +22,7 @@ TEST_SRCS  = test_runner.c test_example.c \
 	test_usb_pci_scan.c test_bt_scan_sync.c \
 	test_vfs_backend_contract.c 	test_stat_user_abi.c \
 	test_named_fifo_supervise.c 	test_path_resolve_at.c \
+	test_path_chroot.c \
 	test_ktm_sched_contract.c test_class_b_ctx_invariant.c test_musl_cred_abi.c test_musl_mmap_contract.c \
 	test_signal_rt_sigaction_abi.c test_mmap_null_placement.c \
 	test_elf_initial_brk_abi.c test_blockdev_facade.c \
@@ -161,6 +162,9 @@ test_named_fifo_supervise.o: test_named_fifo_supervise.c
 	$(CC) $(KERNEL_CFLAGS) -c -o $@ $<
 
 test_path_resolve_at.o: test_path_resolve_at.c
+	$(CC) $(KERNEL_CFLAGS) -c -o $@ $<
+
+test_path_chroot.o: test_path_chroot.c
 	$(CC) $(KERNEL_CFLAGS) -c -o $@ $<
 
 test_ktm_sched_contract.o: test_ktm_sched_contract.c

--- a/tests/host/test_path_chroot.c
+++ b/tests/host/test_path_chroot.c
@@ -1,0 +1,66 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: test_path_chroot.c
+ * Description: Host test — chroot root apply / under / getcwd strip
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#include "test_harness_ir0.h"
+#include <ir0/path.h>
+
+void test_path_chroot(void)
+{
+	char out[256];
+	int rc;
+
+	TEST_BEGIN("path_chroot_apply_identity_root");
+	rc = ir0_path_apply_root("/", "/etc/passwd", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/etc/passwd");
+	rc = ir0_path_apply_root(NULL, "/tmp", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/tmp");
+	TEST_END();
+
+	TEST_BEGIN("path_chroot_apply_jail");
+	rc = ir0_path_apply_root("/jail", "/etc/passwd", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/jail/etc/passwd");
+	rc = ir0_path_apply_root("/jail", "/", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/jail");
+	rc = ir0_path_apply_root("/jail", "/./tmp/../etc", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/jail/etc");
+	TEST_END();
+
+	TEST_BEGIN("path_chroot_under_root");
+	ASSERT_EQ(ir0_path_under_root("/jail", "/jail"), 1);
+	ASSERT_EQ(ir0_path_under_root("/jail", "/jail/tmp"), 1);
+	ASSERT_EQ(ir0_path_under_root("/jail", "/jailx"), 0);
+	ASSERT_EQ(ir0_path_under_root("/jail", "/other"), 0);
+	ASSERT_EQ(ir0_path_under_root("/", "/anything"), 1);
+	TEST_END();
+
+	TEST_BEGIN("path_chroot_getcwd_visible");
+	rc = ir0_path_getcwd_visible("/jail", "/jail", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/");
+	rc = ir0_path_getcwd_visible("/jail", "/jail/tmp", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/tmp");
+	rc = ir0_path_getcwd_visible("/jail", "/home", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/home");
+	rc = ir0_path_getcwd_visible("/", "/home/ivan", out, sizeof(out));
+	ASSERT_EQ(rc, 0);
+	ASSERT_STR_EQ(out, "/home/ivan");
+	TEST_END();
+}

--- a/tests/host/test_runner.c
+++ b/tests/host/test_runner.c
@@ -30,6 +30,7 @@ extern void test_vfs_backend_contract(void);
 extern void test_stat_user_abi(void);
 extern void test_named_fifo_supervise(void);
 extern void test_path_resolve_at(void);
+extern void test_path_chroot(void);
 extern void test_ktm_poll_arch_resume_matrix(void);
 extern void test_class_b_ctx_invariant_matrix(void);
 extern void test_musl_mmap_contract(void);
@@ -74,6 +75,7 @@ static void (*test_functions[])(void) = {
 	test_stat_user_abi,
 	test_named_fifo_supervise,
 	test_path_resolve_at,
+	test_path_chroot,
 	test_ktm_poll_arch_resume_matrix,
 	test_class_b_ctx_invariant_matrix,
 	test_musl_mmap_contract,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Touches all pathname resolution and adds chroot semantics; scheduler/IRQ preempt changes address security-relevant desk crashes but alter when context switches occur.
> 
> **Overview**
> **chroot(2)** is wired end-to-end: per-process host-absolute `root` (fork/exec clone), `sys_chroot` (root-only, no cwd change), `getcwd` jail-relative paths, and `ir0_path_apply_root` / `under_root` / `getcwd_visible` in `fs/path.c`. Path resolution (`path_user` and VFS syscalls including `openat` dirfd paths that skip re-jailing) now takes `current_process->root`.
> 
> **Scheduler / IRQ:** `stdin_wake_check` no longer calls `sched_schedule_next()` from the keyboard path; it sets `clock_request_sched_resched` instead. IRQ exit runs `sched_irq_preempt_from_frame`, with `clock_sched_resched_pending_peek` and a rule that ring-0 interrupt context never preempts mid-ISR. ISR logging for kernel execution in data/BSS uses `_etext`/`_end` instead of only `current_process`.
> 
> **MINIX tooling:** `inject_init_minix.py` counts indirect/double-indirect zones in zmap sync, rebuilds zmap once per inject, and speeds `alloc_zone`; `verify_minix_rootfs.py` reads double-indirect file data.
> 
> **CI / smokes:** musl `chroot_smoke` + `make smoke-chroot`; `smoke_userspace_stability` / matrix `--stability` (top, man, dmesg/pipes, tcc via 9p, optional doom); host `test_path_chroot`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb446be10c14ce5545b8b6d9bcb3ab1ef5e69b12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->