### PR TITLE
fix(tty): no schedule desde IRQ1 en firstboot password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2487,6 +2487,21 @@ smoke-userspace-stability: kernel-x64-userspace.iso
 		--auto-doom
 	@echo "  LOG     $(USERSPACE_STABILITY_LOG)"
 
+# Interactive firstboot wizard (HMP): password Confirm must not #UD under IRQ1.
+FIRSTBOOT_WIZARD_LOG = /tmp/ir0-firstboot-wizard.log
+FIRSTBOOT_WIZARD_DISK ?= $(IR0_USERSPACE_ROOT)/out/x86_64/images/desktop/disk.img
+.PHONY: smoke-firstboot-wizard
+smoke-firstboot-wizard: kernel-x64-userspace.iso
+	@echo "  SMOKE   firstboot wizard (username + password Confirm)..."
+	@test -f $(FIRSTBOOT_WIZARD_DISK) || \
+		{ echo "✗ missing $(FIRSTBOOT_WIZARD_DISK) — pack ISD desktop first"; exit 2; }
+	@chmod +x scripts/smoke_firstboot_wizard.py
+	@python3 scripts/smoke_firstboot_wizard.py \
+		--iso kernel-x64-userspace.iso \
+		--disk $(FIRSTBOOT_WIZARD_DISK) \
+		--log $(FIRSTBOOT_WIZARD_LOG)
+	@echo "  LOG     $(FIRSTBOOT_WIZARD_LOG)"
+
 # Non-root path: crypt(3) auth + setuid drop + /etc/profile PS1 (typed via monitor).
 RUNIT_LOGIN_NONROOT_SMOKE_LOG = /tmp/runit-login-nonroot-smoke.log
 smoke-runit-login-nonroot: load-userspace-runit kernel-x64-userspace.iso

--- a/includes/ir0/console.c
+++ b/includes/ir0/console.c
@@ -515,16 +515,18 @@ void ir0_console_keypress(char c)
 		{
 			canon_line_len = 0;
 			tty_deliver_sig(SIGINT);
-			if (tty_sleep_depth == 0)
-				sched_schedule_next();
+			/*
+			 * Never sched_schedule_next() here: keypress runs under
+			 * IRQ1. Wake + tty_need_resched; ISR / idle_poll switch.
+			 */
+			(void)ir0_console_wake_readers();
 			return;
 		}
 		if ((unsigned char)nc == vquit)
 		{
 			canon_line_len = 0;
 			tty_deliver_sig(SIGQUIT);
-			if (tty_sleep_depth == 0)
-				sched_schedule_next();
+			(void)ir0_console_wake_readers();
 			return;
 		}
 	}
@@ -536,13 +538,12 @@ void ir0_console_keypress(char c)
 		{
 			ir0_ash_smoke_tty_line_ready();
 			/*
-			 * Wake waiters. Schedule only when NOT already inside
-			 * tty_sleep on this stack (nested schedule stranded ash
-			 * after login). IRQ/async path must schedule or the
-			 * shell never runs again after BLOCKED.
+			 * Wake waiters only. Scheduling from IRQ1 (keyboard →
+			 * keypress) corrupted prev RIP → #UD into .bss /
+			 * process_t during firstboot password Confirm.
+			 * sched_irq_preempt_from_frame / idle_poll pick READY.
 			 */
-			if (ir0_console_wake_readers() && tty_sleep_depth == 0)
-				sched_schedule_next();
+			(void)ir0_console_wake_readers();
 		}
 		return;
 	}

--- a/sched/sched_resched.c
+++ b/sched/sched_resched.c
@@ -119,17 +119,19 @@ int sched_irq_preempt_from_frame(uint64_t *gpr_stack)
 		if (ir0_console_in_tty_sleep())
 			return 0;
 
-		(void)ir0_console_take_resched();
-		KTM_EVENT(KTM_EV_SCHED_IRQ_TTY_PREEMPT);
 		/*
 		 * Ring-0 interrupt context (idle / kernel): never schedule here.
-		 * Mid-ISR switch_to corrupts prev RIP/RSP → #UD into BSS on resume.
-		 * Wake left tasks READY; idle_poll / cooperative yield picks them up.
+		 * Mid-ISR switch_to corrupts prev RIP/RSP → #UD into BSS /
+		 * process_t on resume. Leave tty_need_resched pending for
+		 * idle_poll (do not take_resched until we actually switch).
 		 */
 		if ((gpr_stack[18] & 3U) != 3U)
 			return 0;
 		if (sched_count_runnable() <= 1)
 			return 0;
+
+		(void)ir0_console_take_resched();
+		KTM_EVENT(KTM_EV_SCHED_IRQ_TTY_PREEMPT);
 		process_save_user_context_from_irq_frame(gpr_stack);
 		sched_context_switch_skip_prev_save();
 		sched_schedule_next();

--- a/scripts/smoke_firstboot_wizard.py
+++ b/scripts/smoke_firstboot_wizard.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""Interactive firstboot wizard smoke (HMP): username + password Confirm.
+
+Repro for #UD when sched_schedule_next ran under keyboard IRQ on Enter.
+PASS: FIRSTBOOT_OK or login prompt without KERNEL PANIC / #UD.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ISD = ROOT.parent / "ISD"
+
+SPECIAL = {
+    " ": "spc",
+    "/": "slash",
+    "-": "minus",
+    ".": "dot",
+    "_": "shift-minus",
+}
+
+FAIL_RE = re.compile(
+    r"KERNEL PANIC|#UD\b|Unhandled kernel|KERNEL_EXECUTE_BSS|DOUBLE FAULT"
+)
+USER_PROMPT = re.compile(r"Enter your Unix username:")
+HOST_PROMPT = re.compile(r"Hostname")
+PASS_PROMPT = re.compile(r"Password:")
+CONFIRM_PROMPT = re.compile(r"Confirm password:")
+DONE_RE = re.compile(
+    r"FIRSTBOOT_OK|Account '.+' created|login:|ASH_INTERACTIVE_READY|GETTY_READY"
+)
+
+
+def mon_send(port: int, cmd: str) -> None:
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as s:
+        s.settimeout(0.4)
+        try:
+            s.recv(4096)
+        except OSError:
+            pass
+        s.sendall((cmd + "\n").encode())
+        time.sleep(0.05)
+        try:
+            s.recv(4096)
+        except OSError:
+            pass
+
+
+def type_str(port: int, text: str, delay: float = 0.12) -> None:
+    for ch in text:
+        if ch in SPECIAL:
+            mon_send(port, f"sendkey {SPECIAL[ch]}")
+        elif ch.isupper():
+            mon_send(port, f"sendkey shift-{ch.lower()}")
+        else:
+            mon_send(port, f"sendkey {ch}")
+        time.sleep(delay)
+    mon_send(port, "sendkey ret")
+    time.sleep(0.35)
+
+
+def wait_re(log: Path, rx: re.Pattern[str], proc: subprocess.Popen, limit: float) -> str:
+    t0 = time.time()
+    while time.time() - t0 < limit:
+        text = log.read_text(errors="replace")
+        if FAIL_RE.search(text):
+            return text
+        if rx.search(text):
+            return text
+        if proc.poll() is not None:
+            return text
+        time.sleep(0.2)
+    return log.read_text(errors="replace")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iso", type=Path, default=ROOT / "kernel-x64-userspace.iso")
+    ap.add_argument(
+        "--disk",
+        type=Path,
+        default=ISD / "out/x86_64/images/desktop/disk.img",
+    )
+    ap.add_argument("--log", type=Path, default=Path("/tmp/ir0-firstboot-wizard.log"))
+    ap.add_argument("--port", type=int, default=46201)
+    ap.add_argument("--timeout", type=float, default=120.0)
+    ap.add_argument("--user", default="ivan")
+    ap.add_argument("--password", default="ivan")
+    args = ap.parse_args()
+
+    if not args.iso.is_file() or not args.disk.is_file():
+        print(f"✗ need iso+disk: {args.iso} {args.disk}", file=sys.stderr)
+        return 2
+
+    disk = Path(tempfile.mktemp(prefix="ir0-fbwiz.", suffix=".img"))
+    shutil.copy2(args.disk, disk)
+    args.log.write_text("")
+    subprocess.run(
+        ["pkill", "-f", f"qemu-system-x86_64.*127.0.0.1:{args.port}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(0.3)
+
+    qemu = [
+        "qemu-system-x86_64",
+        "-cdrom",
+        str(args.iso),
+        "-drive",
+        f"file={disk},format=raw,if=ide,index=0",
+        "-serial",
+        f"file:{args.log}",
+        "-display",
+        "none",
+        "-m",
+        "512M",
+        "-no-reboot",
+        "-net",
+        "none",
+        "-monitor",
+        f"tcp:127.0.0.1:{args.port},server,nowait",
+    ]
+    proc = subprocess.Popen(qemu, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        text = wait_re(log=args.log, rx=USER_PROMPT, proc=proc, limit=min(90.0, args.timeout))
+        if FAIL_RE.search(text):
+            print("✗ panic before username prompt", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+        if not USER_PROMPT.search(text):
+            print("✗ timeout waiting for username prompt", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+
+        time.sleep(1.0)
+        type_str(args.port, args.user)
+        text = wait_re(args.log, HOST_PROMPT, proc, 40.0)
+        if FAIL_RE.search(text):
+            print("✗ panic after username", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+
+        type_str(args.port, "unix")
+        text = wait_re(args.log, PASS_PROMPT, proc, 40.0)
+        if FAIL_RE.search(text):
+            print("✗ panic after hostname", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+
+        # Password (no echo) + Confirm — Enter used to #UD under IRQ schedule.
+        type_str(args.port, args.password)
+        text = wait_re(args.log, CONFIRM_PROMPT, proc, 40.0)
+        if FAIL_RE.search(text):
+            print("✗ panic after Password Enter (IRQ schedule bug)", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+
+        type_str(args.port, args.password)
+        text = wait_re(args.log, DONE_RE, proc, 60.0)
+        if FAIL_RE.search(text):
+            print("✗ panic after Confirm password", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+        if not DONE_RE.search(text):
+            print("✗ wizard did not complete", file=sys.stderr)
+            print(text[-2500:], file=sys.stderr)
+            return 1
+
+        print("✓ smoke-firstboot-wizard OK")
+        return 0
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                proc.kill()
+        disk.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Evita `sched_schedule_next()` desde `ir0_console_keypress` (IRQ1) al completar Enter en password del firstboot.
- `sched_irq_preempt`: no limpia `tty_need_resched` en ring-0 sin switch.
- Smoke HMP `smoke-firstboot-wizard`.

## Test plan
- [x] `python3 scripts/smoke_firstboot_wizard.py` ×2 OK
- [x] `make arch-guard` OK
- [ ] Wizard manual con ISO nueva

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core TTY wake and IRQ preempt scheduling paths; behavior change is intentional but could affect login/shell readiness timing outside firstboot.
> 
> **Overview**
> Fixes **#UD / kernel panic** when pressing Enter during the firstboot **password Confirm** step, caused by **`sched_schedule_next()` running from IRQ1** (`ir0_console_keypress`) and corrupting saved RIP/RSP on resume.
> 
> **TTY / console:** On **^C/^\\** and when a **canonical line completes**, the handler now only **`ir0_console_wake_readers()`** and returns—no inline schedule. Woken tasks stay **READY**; **`idle_poll`** / **`sched_irq_preempt_from_frame`** (user context) perform the switch.
> 
> **Scheduler:** For TTY-wake preempt (`why == 2`), **`ir0_console_take_resched()`** runs only after checks pass (not in nested `tty_sleep`, ring-0 ISR bails without switching, runnable > 1). Ring-0 interrupt context no longer clears **`tty_need_resched`** without actually preempting, so **`idle_poll`** can pick up the reader later.
> 
> **CI:** Adds **`scripts/smoke_firstboot_wizard.py`** and **`make smoke-firstboot-wizard`** to drive the HMP firstboot wizard (username, hostname, password + confirm) via QEMU monitor and fail on panic/#UD.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d35c0992d3eb0b563e4f6b28bc5d67e6e5c1a60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->