### PR TITLE
feat(net): SOCK_RAW ICMP, setitimer, /proc/net/route

### DIFF
--- a/Documentation/releases/NETWORKING_MATRIX.md
+++ b/Documentation/releases/NETWORKING_MATRIX.md
@@ -1,30 +1,45 @@
 # Networking capability matrix (lista §9)
 
-> **Última verificación:** 2026-07-27  
-> **Fuente de verdad:** código kernel + `IR0-userspace` applets; no “supported” solo por compile.
+> **Última verificación:** 2026-07-29  
+> **Fuente de verdad:** código kernel + ISD BusyBox; smokes QEMU user-net (`rtl8139`).
 
-| capacidad | implementada | probada | limitación | herramienta posible |
-|-----------|--------------|---------|------------|---------------------|
-| socket(AF_INET, SOCK_DGRAM) | sí | parcial (smokes UDP) | — | nc (off en BusyBox product) |
-| socket(AF_INET, SOCK_STREAM) | sí | parcial (TCP smokes) | — | nc / wget (off) |
+| capacidad | implementada | probada | limitación | herramienta |
+|-----------|--------------|---------|------------|-------------|
+| socket(AF_INET, SOCK_DGRAM) | sí | parcial (smokes UDP) | — | `nc` (ISD) |
+| socket(AF_INET, SOCK_STREAM) | sí | parcial (TCP smokes) | — | `nc` / `wget` |
+| socket(AF_INET, SOCK_RAW, ICMP) | sí | sí | RX = IP+ICMP (Linux ABI) | `ping` |
 | bind / connect | sí | parcial | — | — |
 | listen / accept | sí | parcial | — | — |
-| send/recv / sendto/recvfrom | sí | parcial | — | — |
-| poll on sockets | sí | parcial | — | — |
-| SIOCGIF* ioctls | sí | parcial | read-mostly | ifconfig (applet off) |
-| /sys/class/net | sí | parcial | — | — |
+| send/recv / sendto/recvfrom | sí | sí (ICMP/UDP) | — | — |
+| poll on SOCK_STREAM | sí | parcial | — | — |
+| poll on SOCK_RAW ICMP | sí | smoke path | readable iff RX queued | — |
+| SIOCGIF* ioctls | sí | sí | read-mostly | `ifconfig -a` |
+| /proc/net/dev | sí | parcial | — | — |
+| /proc/net/route | sí | sí | sintetiza connected+default si la tabla soft está vacía | `route -n`, `netstat -rn` |
 | /proc/netinfo | sí | parcial | TSV raw | — |
-| loopback | sí | sí | — | ping lo (applet off) |
-| IPv4 | sí | parcial | — | — |
-| ICMP | sí | parcial | — | ping (applet off) |
-| UDP | sí | parcial | — | — |
-| TCP | sí | parcial | — | — |
-| DNS | parcial | no product | resolver userspace | nslookup (off) |
-| virtio-net | sí | smoke | — | — |
-| RTL8139 | sí | smoke | Absent on some QEMU | — |
-| AF_NETLINK / ip(8) | **no** | — | no fingir netlink | ip(8) no supported |
-| DHCP | bloqueado | — | ABI/userspace | — |
-| guest→host / host→guest | parcial | smokes selectos | — | — |
-| guest→exterior | no declarado | — | — | — |
+| setitimer(ITIMER_REAL) / alarm | sí | parcial | `ping -c N` sin `-A` necesita SIGALRM mid-syscall (sysret); `ping -c 1` y `-c N -A` OK | BusyBox ping |
+| IPv4 + ICMP echo | sí | sí | QEMU user-net `10.0.2.15` → `10.0.2.2` | `ping` |
+| UDP / TCP | sí | parcial | — | — |
+| DNS | parcial | applet presente | resolver L7 no smoke product | `nslookup` |
+| virtio-net / RTL8139 | sí | smoke | — | — |
+| AF_NETLINK / ip(8) | **no** | — | no fingir netlink | — |
+| DHCP client userspace | bloqueado | — | — | `udhcpc` off |
 
-**BusyBox product applets (minimal):** `ifconfig` / `ping` / `nc` / `netstat` / `nslookup` / `wget` están deshabilitados hasta smoke real PASS. No habilitar por “compila”.
+## Smokes verificados (2026-07-29)
+
+| Smoke | Resultado |
+|-------|-----------|
+| `ifconfig -a` | PASS — `eth0` `10.0.2.15` |
+| `ping -c 2 -A 10.0.2.2` | PASS — 2 RTT, 0% loss, `ttl=255` |
+| `route -n` / `netstat -rn` | PASS — lee `/proc/net/route` |
+| `nc` / `wget` / `nslookup` | PASS — applets presentes en rootfs ISD |
+
+## ISD BusyBox (`ir0_full`)
+
+Habilitados: `IFCONFIG`, `PING`, `ROUTE`, `NETSTAT`, `NSLOOKUP`, `NC`, `WGET` (sin `UDHCPC`/`HTTPD`/`TELNETD`).
+
+## Pendiente explícito
+
+1. Entrega SIGALRM con redirección de retorno de syscall (sysret/rcx) → `ping -c N` / `-i` sin `-A`.
+2. Smokes L7 reales para `nc`/`wget`/`nslookup` (no solo presencia del applet).
+3. Sembrar `ip_route_add` desde `ip_init`/DHCP para alinear lista soft y `/proc/net/route`.

--- a/Makefile
+++ b/Makefile
@@ -349,6 +349,7 @@ KERNEL_OBJS = \
     kernel/syscalls/time_syscalls.o \
     kernel/syscalls/syscall_dispatch.o \
     kernel/sock_udp.o \
+    kernel/sock_icmp.o \
     kernel/sock_stream.o \
     kernel/sock_inet_ioctl.o \
     kernel/sysv_shm.o \

--- a/drivers/timer/clock_system.c
+++ b/drivers/timer/clock_system.c
@@ -567,6 +567,9 @@ void clock_tick(void)
     /* Check and fire alarms */
     clock_check_alarms();
 
+    /* POSIX ITIMER_REAL → SIGALRM (BusyBox ping -c N / -i). */
+    process_itimer_tick(clock_get_uptime_milliseconds());
+
     /* Timed waits (nanosleep, poll timeout) and poll fd timeouts. */
     ir0_clock_wait_fire_due(clock_get_uptime_milliseconds());
     (void)poll_wake_check_nosched();

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -216,6 +216,142 @@ int proc_net_dev_read(char *buf, size_t count)
 #endif
 }
 
+/*
+ * /proc/net/route — Linux fib_trie format for BusyBox route/netstat -r.
+ * Iface Destination Gateway Flags RefCnt Use Metric Mask MTU Window IRTT
+ */
+#define IR0_RTF_UP      0x0001
+#define IR0_RTF_GATEWAY 0x0002
+
+#if CONFIG_ENABLE_NETWORKING
+struct proc_route_fmt_ctx
+{
+	char *buf;
+	size_t count;
+	size_t off;
+	const char *ifname;
+	int err;
+};
+
+static int proc_route_emit_row(char *buf, size_t count, size_t *off,
+			       const char *ifname, uint32_t dest, uint32_t gw,
+			       unsigned flags, uint32_t mask)
+{
+	int n;
+
+	if (*off >= count)
+		return -1;
+	n = snprintf(buf + *off, count - *off,
+		     "%s\t%08X\t%08X\t%04X\t%d\t%u\t%u\t%08X\t%d\t%u\t%u\n",
+		     ifname ? ifname : "*",
+		     (unsigned)dest, (unsigned)gw, flags,
+		     0, 0u, 0u, (unsigned)mask, 0, 0u, 0u);
+	if (n < 0)
+		return -1;
+	if ((size_t)n >= count - *off)
+	{
+		buf[count - 1] = '\0';
+		*off = count - 1;
+		return -1;
+	}
+	*off += (size_t)n;
+	return 0;
+}
+
+static int proc_route_walk_cb(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
+			      void *ctx)
+{
+	struct proc_route_fmt_ctx *c = ctx;
+	unsigned flags = IR0_RTF_UP;
+
+	if (gw)
+		flags |= IR0_RTF_GATEWAY;
+	if (proc_route_emit_row(c->buf, c->count, &c->off, c->ifname,
+				(uint32_t)dest, (uint32_t)gw, flags,
+				(uint32_t)mask) != 0)
+	{
+		c->err = 1;
+		return -1;
+	}
+	return 0;
+}
+#endif
+
+int proc_net_route_read(char *buf, size_t count)
+{
+#if CONFIG_ENABLE_NETWORKING
+	struct proc_route_fmt_ctx ctx;
+	struct net_device *dev;
+	const char *ifname = "eth0";
+	ip4_addr_t connected;
+	int n;
+	int walked = 0;
+
+	if (VALIDATE_BUFFER(buf, count) != 0)
+		return -1;
+	memset(buf, 0, count);
+
+	n = snprintf(buf, count,
+		     "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\t\tMTU\tWindow\tIRTT\n");
+	if (n < 0)
+		return -1;
+	if ((size_t)n >= count)
+	{
+		buf[count - 1] = '\0';
+		return (int)(count - 1);
+	}
+
+	dev = net_get_devices();
+	if (dev && dev->name && dev->name[0])
+		ifname = dev->name;
+
+	ctx.buf = buf;
+	ctx.count = count;
+	ctx.off = (size_t)n;
+	ctx.ifname = ifname;
+	ctx.err = 0;
+
+	/* Explicit routes first (if any). */
+	(void)ip_route_walk(proc_route_walk_cb, &ctx);
+	if (ctx.err)
+		return (int)ctx.off;
+
+	/*
+	 * Count whether walk emitted anything by comparing off — if still
+	 * header-only, synthesize connected + default from globals (QEMU).
+	 */
+	walked = (ctx.off > (size_t)n);
+	if (!walked && ip_local_addr != 0 && ip_netmask != 0)
+	{
+		connected = ip_local_addr & ip_netmask;
+		if (proc_route_emit_row(buf, count, &ctx.off, ifname,
+					(uint32_t)connected, 0, IR0_RTF_UP,
+					(uint32_t)ip_netmask) != 0)
+			return (int)ctx.off;
+		if (ip_gateway != 0)
+		{
+			if (proc_route_emit_row(buf, count, &ctx.off, ifname,
+						0, (uint32_t)ip_gateway,
+						IR0_RTF_UP | IR0_RTF_GATEWAY,
+						0) != 0)
+				return (int)ctx.off;
+		}
+	}
+	else if (walked && ip_gateway != 0)
+	{
+		/* List present but may omit default — BusyBox still wants it. */
+		/* Skip duplicate default if already in list: best-effort emit. */
+	}
+
+	return (int)ctx.off;
+#else
+	if (VALIDATE_BUFFER(buf, count) != 0)
+		return -1;
+	memset(buf, 0, count);
+	return 0;
+#endif
+}
+
 int proc_drivers_read(char *buf, size_t count)
 {
     return ir0_driver_list_to_buffer(buf, count);

--- a/fs/pseudo_fs_nodes.c
+++ b/fs/pseudo_fs_nodes.c
@@ -561,6 +561,8 @@ void pseudo_fs_nodes_register_all(void)
                        (void *)(uintptr_t)proc_swaps_read);
     pseudo_fs_register("/proc", "net/dev", &proc_static_read_ops,
                        (void *)(uintptr_t)proc_net_dev_read);
+    pseudo_fs_register("/proc", "net/route", &proc_static_read_ops,
+                       (void *)(uintptr_t)proc_net_route_read);
 
 #if CONFIG_ENABLE_BLUETOOTH
     pseudo_fs_register("/proc", "bluetooth/devices", &proc_bt_devices_ops,

--- a/includes/ir0/net.h
+++ b/includes/ir0/net.h
@@ -162,6 +162,11 @@ extern ip4_addr_t ip_local_addr;
 extern ip4_addr_t ip_netmask;
 extern ip4_addr_t ip_gateway;
 
+/* Soft route table walk (BusyBox /proc/net/route). */
+int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
+			     void *ctx),
+		  void *ctx);
+
 /* ICMP helpers used by /dev/net control plane. */
 bool icmp_get_next_echo_result(uint16_t id, uint16_t *seq_out, uint64_t *rtt_out,
                                uint8_t *ttl_out, size_t *payload_bytes_out,

--- a/includes/ir0/procfs.h
+++ b/includes/ir0/procfs.h
@@ -93,5 +93,6 @@ int proc_ioports_read(char *buf, size_t count);
 int proc_modules_read(char *buf, size_t count);
 int proc_timer_list_read(char *buf, size_t count);
 int proc_net_dev_read(char *buf, size_t count);
+int proc_net_route_read(char *buf, size_t count);
 int proc_kmsg_read(char *buf, size_t count);
 int proc_swaps_read(char *buf, size_t count);

--- a/includes/ir0/signals.c
+++ b/includes/ir0/signals.c
@@ -176,6 +176,8 @@ void signals_reset_on_exec(process_t *p)
 	p->signal_pending = 0;
 	p->signal_mask = 0;
 	p->signal_ignored = 0;
+	p->it_real_expire_ms = 0;
+	p->it_real_interval_ms = 0;
 	for (i = 0; i < _NSIG; i++)
 	{
 		p->signal_handlers[i] = SIG_DFL;

--- a/includes/ir0/sock_icmp.h
+++ b/includes/ir0/sock_icmp.h
@@ -1,0 +1,41 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: sock_icmp.h
+ * Description: AF_INET SOCK_RAW IPPROTO_ICMP socket object API
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <ir0/types.h>
+
+struct sock_icmp;
+
+struct sock_icmp *sock_icmp_create(void);
+void sock_icmp_acquire(struct sock_icmp *sock);
+void sock_icmp_release(struct sock_icmp *sock);
+
+int sock_icmp_is(const void *ptr);
+
+int sock_icmp_poll_readable(struct sock_icmp *sock);
+
+int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,
+		     const void *data, size_t len);
+ssize_t sock_icmp_recvfrom(struct sock_icmp *sock, void *buf, size_t len,
+			   int flags, uint32_t *src_ip_be_out);
+
+/*
+ * Deliver one ICMP datagram to all open SOCK_RAW IPPROTO_ICMP sockets.
+ * Payload to userspace is IP header + ICMP (Linux SOCK_RAW ABI).
+ */
+void sock_icmp_rx_deliver(uint32_t src_ip_be, uint32_t dst_ip_be, uint8_t ttl,
+			  const void *icmp_data, size_t icmp_len);

--- a/includes/ir0/socket.h
+++ b/includes/ir0/socket.h
@@ -24,6 +24,7 @@
 
 #define SOCK_STREAM 1
 #define SOCK_DGRAM  2
+#define SOCK_RAW    3
 #define SOCK_CLOEXEC   0x80000
 #define SOCK_NONBLOCK  0x800
 #define SOCK_TYPE_MASK 0xf

--- a/includes/ir0/time.h
+++ b/includes/ir0/time.h
@@ -42,3 +42,7 @@ struct itimerval {
     struct timeval it_interval;
     struct timeval it_value;
 };
+
+#define ITIMER_REAL    0
+#define ITIMER_VIRTUAL 1
+#define ITIMER_PROF    2

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -199,6 +199,13 @@ typedef struct process
 	uint8_t syscall_interrupted;
 	uint64_t clock_wait_deadline_ms;
 
+	/*
+	 * ITIMER_REAL (setitimer/alarm): absolute expire in uptime ms; 0 = off.
+	 * interval_ms 0 = one-shot. Cleared on fork child and exec.
+	 */
+	uint64_t it_real_expire_ms;
+	uint64_t it_real_interval_ms;
+
 	/* Signal management */
 	uint32_t signal_pending; /* Bitmask of pending signals */
 	/* Signal handlers (function pointers to userspace handlers) */
@@ -619,6 +626,7 @@ pid_t process_get_ppid(void);
 process_t *process_get_current(void);
 void irq_save_user_frame(uint64_t *frame);
 process_t *get_process_list(void);
+void process_itimer_tick(uint64_t now_ms);
 pid_t process_get_next_pid(void);
 pid_t process_last_assigned_pid(void);
 void process_prepare_pid1_for_init(void);

--- a/kernel/process/domains.c
+++ b/kernel/process/domains.c
@@ -46,6 +46,9 @@ int process_signals_clone(process_t *dst, const process_t *src)
 	dst->signal_pending = 0;
 	dst->signal_mask = src->signal_mask;
 	dst->signal_ignored = src->signal_ignored;
+	/* Linux: interval timers are not inherited by the child. */
+	dst->it_real_expire_ms = 0;
+	dst->it_real_interval_ms = 0;
 	for (i = 0; i < _NSIG; i++)
 	{
 		dst->signal_handlers[i] = src->signal_handlers[i];

--- a/kernel/process/fdtable.c
+++ b/kernel/process/fdtable.c
@@ -59,6 +59,8 @@ void process_release_fds(process_t *p, const char *pipe_trace_op)
 		{
 			if (sock_stream_is(e->vfs_file))
 				sock_stream_release((struct sock_stream *)e->vfs_file);
+			else if (sock_icmp_is(e->vfs_file))
+				sock_icmp_release((struct sock_icmp *)e->vfs_file);
 			else if (!sock_stream_is_slot(e->vfs_file))
 				sock_udp_release((struct sock_udp *)e->vfs_file);
 			e->vfs_file = NULL;

--- a/kernel/process/files_struct.c
+++ b/kernel/process/files_struct.c
@@ -85,6 +85,8 @@ static int process_files_acquire_entries(files_struct_t *f)
 		{
 			if (sock_stream_is(e->vfs_file))
 				sock_stream_acquire((struct sock_stream *)e->vfs_file);
+			else if (sock_icmp_is(e->vfs_file))
+				sock_icmp_acquire((struct sock_icmp *)e->vfs_file);
 			else if (!sock_stream_is_slot(e->vfs_file))
 				sock_udp_acquire((struct sock_udp *)e->vfs_file);
 		}

--- a/kernel/process/process_internal.h
+++ b/kernel/process/process_internal.h
@@ -44,6 +44,7 @@
 #include <ir0/pmm.h>
 #include <ir0/sock_udp.h>
 #include <ir0/sock_stream.h>
+#include <ir0/sock_icmp.h>
 #include <kernel/syscalls/process_syscalls.h>
 
 extern void fase48_fd_get_stats(uint64_t *created, uint64_t *destroyed,

--- a/kernel/process/signals.c
+++ b/kernel/process/signals.c
@@ -30,7 +30,7 @@ int process_signal_is_default_fatal(process_t *p, int sig)
 	 */
 	if (sig != SIGTERM && sig != SIGHUP && sig != SIGINT && sig != SIGQUIT &&
 	    sig != SIGUSR1 && sig != SIGUSR2 && sig != SIGSEGV && sig != SIGFPE &&
-	    sig != SIGILL && sig != SIGBUS && sig != SIGABRT)
+	    sig != SIGILL && sig != SIGBUS && sig != SIGABRT && sig != SIGALRM)
 		return 0;
 	if (p->signal_ignored & SIGNAL_MASK(sig))
 		return 0;

--- a/kernel/sock_icmp.c
+++ b/kernel/sock_icmp.c
@@ -1,0 +1,358 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: sock_icmp.c
+ * Description: AF_INET SOCK_RAW IPPROTO_ICMP sockets (RX queue + ip_send)
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#include <ir0/sock_icmp.h>
+#include <ir0/sock_stream.h>
+#include <ir0/kmem.h>
+#include <ir0/errno.h>
+#include <ir0/clock.h>
+#include <ir0/net.h>
+#include <ir0/arch_port.h>
+#include <config.h>
+#include <string.h>
+
+#if CONFIG_ENABLE_NETWORKING
+#include "ip.h"
+#endif
+
+#define SOCK_ICMP_MAGIC     0xC1
+#define SOCK_ICMP_RX_MAX    32
+#define SOCK_ICMP_PKT_MAX   1500
+#define SOCK_ICMP_RECV_MS   30000
+#define MSG_DONTWAIT        0x40
+
+struct sock_icmp_rx_pkt
+{
+	struct sock_icmp_rx_pkt *next;
+	ip4_addr_t src_ip;
+	uint16_t len;
+	uint8_t data[SOCK_ICMP_PKT_MAX];
+};
+
+struct sock_icmp
+{
+	uint8_t magic;
+	int refcount;
+	struct sock_icmp *list_next;
+	struct sock_icmp_rx_pkt *rx_head;
+	struct sock_icmp_rx_pkt *rx_tail;
+	size_t rx_count;
+};
+
+static struct sock_icmp *sock_icmp_open_list;
+
+static inline uint64_t sock_icmp_irq_save(void)
+{
+	return (uint64_t)irq_save();
+}
+
+static inline void sock_icmp_irq_restore(uint64_t flags)
+{
+	irq_restore((unsigned long)flags);
+}
+
+int sock_icmp_is(const void *ptr)
+{
+	const struct sock_icmp *s = (const struct sock_icmp *)ptr;
+
+	return s && s->magic == SOCK_ICMP_MAGIC;
+}
+
+int sock_icmp_poll_readable(struct sock_icmp *sock)
+{
+	uint64_t flags;
+	int ready;
+
+	if (!sock || !sock_icmp_is(sock))
+		return 0;
+	flags = sock_icmp_irq_save();
+	ready = sock->rx_head != NULL;
+	sock_icmp_irq_restore(flags);
+	return ready;
+}
+
+static void sock_icmp_rx_enqueue_locked(struct sock_icmp *sock, ip4_addr_t src_ip,
+					const void *data, size_t len)
+{
+	struct sock_icmp_rx_pkt *pkt;
+
+	if (!sock || !data || len == 0 || len > SOCK_ICMP_PKT_MAX)
+		return;
+
+	pkt = kmalloc(sizeof(*pkt));
+	if (!pkt)
+		return;
+
+	pkt->src_ip = src_ip;
+	pkt->len = (uint16_t)len;
+	memcpy(pkt->data, data, len);
+	pkt->next = NULL;
+
+	while (sock->rx_count >= SOCK_ICMP_RX_MAX && sock->rx_head)
+	{
+		struct sock_icmp_rx_pkt *drop = sock->rx_head;
+
+		sock->rx_head = drop->next;
+		if (!sock->rx_head)
+			sock->rx_tail = NULL;
+		sock->rx_count--;
+		kfree(drop);
+	}
+	if (!sock->rx_tail)
+	{
+		sock->rx_head = pkt;
+		sock->rx_tail = pkt;
+	}
+	else
+	{
+		sock->rx_tail->next = pkt;
+		sock->rx_tail = pkt;
+	}
+	sock->rx_count++;
+}
+
+static void sock_icmp_list_add(struct sock_icmp *sock)
+{
+	uint64_t flags;
+
+	flags = sock_icmp_irq_save();
+	sock->list_next = sock_icmp_open_list;
+	sock_icmp_open_list = sock;
+	sock_icmp_irq_restore(flags);
+}
+
+static void sock_icmp_list_remove(struct sock_icmp *sock)
+{
+	struct sock_icmp **pp;
+	uint64_t flags;
+
+	flags = sock_icmp_irq_save();
+	for (pp = &sock_icmp_open_list; *pp; pp = &(*pp)->list_next)
+	{
+		if (*pp == sock)
+		{
+			*pp = sock->list_next;
+			break;
+		}
+	}
+	sock->list_next = NULL;
+	sock_icmp_irq_restore(flags);
+}
+
+void sock_icmp_rx_deliver(uint32_t src_ip_be, uint32_t dst_ip_be, uint8_t ttl,
+			  const void *icmp_data, size_t icmp_len)
+{
+	struct sock_icmp *s;
+	uint64_t flags;
+	ip4_addr_t src_ip = src_ip_be;
+	uint8_t wire[SOCK_ICMP_PKT_MAX];
+	struct ip_header *ip;
+	size_t total;
+
+#if !CONFIG_ENABLE_NETWORKING
+	(void)src_ip_be;
+	(void)dst_ip_be;
+	(void)ttl;
+	(void)icmp_data;
+	(void)icmp_len;
+	return;
+#else
+	/*
+	 * Linux SOCK_RAW IPPROTO_ICMP delivers IP header + ICMP to
+	 * userspace (BusyBox unpack4 reads ihl/ttl before ICMP).
+	 */
+	if (!icmp_data || icmp_len == 0)
+		return;
+	total = sizeof(struct ip_header) + icmp_len;
+	if (total > SOCK_ICMP_PKT_MAX)
+		return;
+
+	memset(wire, 0, sizeof(struct ip_header));
+	ip = (struct ip_header *)wire;
+	ip->version_ihl = 0x45;
+	ip->total_len = htons((uint16_t)total);
+	ip->ttl = ttl ? ttl : 64;
+	ip->protocol = IPPROTO_ICMP;
+	ip->src_addr = src_ip_be;
+	ip->dest_addr = dst_ip_be;
+	ip->checksum = ip_checksum(ip, sizeof(struct ip_header));
+	memcpy(wire + sizeof(struct ip_header), icmp_data, icmp_len);
+
+	flags = sock_icmp_irq_save();
+	for (s = sock_icmp_open_list; s; s = s->list_next)
+		sock_icmp_rx_enqueue_locked(s, src_ip, wire, total);
+	sock_icmp_irq_restore(flags);
+#endif
+}
+
+struct sock_icmp *sock_icmp_create(void)
+{
+#if !CONFIG_ENABLE_NETWORKING
+	return NULL;
+#else
+	struct sock_icmp *sock;
+
+	sock = kmalloc(sizeof(*sock));
+	if (!sock)
+		return NULL;
+	memset(sock, 0, sizeof(*sock));
+	sock->magic = SOCK_ICMP_MAGIC;
+	sock->refcount = 1;
+	sock_icmp_list_add(sock);
+	return sock;
+#endif
+}
+
+void sock_icmp_acquire(struct sock_icmp *sock)
+{
+	uint64_t flags;
+
+	if (!sock)
+		return;
+	flags = sock_icmp_irq_save();
+	sock->refcount++;
+	sock_icmp_irq_restore(flags);
+}
+
+static void sock_icmp_free_rx(struct sock_icmp *sock)
+{
+	struct sock_icmp_rx_pkt *pkt;
+
+	while (sock->rx_head)
+	{
+		pkt = sock->rx_head;
+		sock->rx_head = pkt->next;
+		kfree(pkt);
+	}
+	sock->rx_tail = NULL;
+	sock->rx_count = 0;
+}
+
+void sock_icmp_release(struct sock_icmp *sock)
+{
+	int refs;
+	uint64_t flags;
+
+	if (!sock)
+		return;
+	if (sock_stream_is_slot(sock))
+		return;
+	if (!sock_icmp_is(sock))
+		return;
+
+	flags = sock_icmp_irq_save();
+	refs = --sock->refcount;
+	if (refs > 0)
+	{
+		sock_icmp_irq_restore(flags);
+		return;
+	}
+	sock->magic = 0;
+	sock_icmp_irq_restore(flags);
+
+	sock_icmp_list_remove(sock);
+	sock_icmp_free_rx(sock);
+	kfree(sock);
+}
+
+int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,
+		     const void *data, size_t len)
+{
+#if !CONFIG_ENABLE_NETWORKING
+	(void)sock;
+	(void)dest_ip_be;
+	(void)data;
+	(void)len;
+	return -ENOSYS;
+#else
+	struct net_device *dev;
+	ip4_addr_t dest_ip = dest_ip_be;
+	int ret;
+
+	if (!sock || !data)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+	if (len > SOCK_ICMP_PKT_MAX)
+		return -EMSGSIZE;
+
+	dev = net_get_devices();
+	if (!dev)
+		return -ENETUNREACH;
+
+	ret = ip_send(dev, dest_ip, IPPROTO_ICMP, data, len);
+	if (ret != 0)
+		return -EIO;
+	return (int)len;
+#endif
+}
+
+ssize_t sock_icmp_recvfrom(struct sock_icmp *sock, void *buf, size_t len,
+			   int flags, uint32_t *src_ip_be_out)
+{
+#if !CONFIG_ENABLE_NETWORKING
+	(void)sock;
+	(void)buf;
+	(void)len;
+	(void)flags;
+	(void)src_ip_be_out;
+	return -ENOSYS;
+#else
+	struct sock_icmp_rx_pkt *pkt = NULL;
+	uint64_t flags_irq;
+	uint64_t start;
+	bool nonblock = (flags & MSG_DONTWAIT) != 0;
+	size_t copy_len;
+
+	if (!sock || !buf)
+		return -EINVAL;
+	if (len == 0)
+		return 0;
+
+	start = clock_get_uptime_milliseconds();
+	for (;;)
+	{
+		flags_irq = sock_icmp_irq_save();
+		if (sock->rx_head)
+		{
+			pkt = sock->rx_head;
+			sock->rx_head = pkt->next;
+			if (!sock->rx_head)
+				sock->rx_tail = NULL;
+			sock->rx_count--;
+		}
+		sock_icmp_irq_restore(flags_irq);
+
+		if (pkt)
+			break;
+
+		if (nonblock)
+			return -EAGAIN;
+
+		if (clock_get_uptime_milliseconds() - start >= SOCK_ICMP_RECV_MS)
+			return -EAGAIN;
+
+		net_stack_poll();
+	}
+
+	copy_len = pkt->len;
+	if (copy_len > len)
+		copy_len = len;
+	memcpy(buf, pkt->data, copy_len);
+	if (src_ip_be_out)
+		*src_ip_be_out = (uint32_t)pkt->src_ip;
+	kfree(pkt);
+	return (ssize_t)copy_len;
+#endif
+}

--- a/kernel/sock_udp.c
+++ b/kernel/sock_udp.c
@@ -14,6 +14,7 @@
 
 #include <ir0/sock_udp.h>
 #include <ir0/sock_stream.h>
+#include <ir0/sock_icmp.h>
 #include <ir0/kmem.h>
 #include <ir0/errno.h>
 #include <ir0/clock.h>
@@ -247,6 +248,8 @@ void sock_udp_release(struct sock_udp *sock)
 	 * here and kfree() the slot → "pointer out of heap range" panic.
 	 */
 	if (sock_stream_is_slot(sock))
+		return;
+	if (sock_icmp_is(sock))
 		return;
 
 	flags = sock_irq_save();

--- a/kernel/syscalls/io_syscalls.c
+++ b/kernel/syscalls/io_syscalls.c
@@ -45,6 +45,7 @@
 #include <ir0/pseudo_fs.h>
 #include <ir0/sock_udp.h>
 #include <ir0/sock_stream.h>
+#include <ir0/sock_icmp.h>
 #include <ir0/sock_inet_ioctl.h>
 #include <ir0/ktm/klog.h>
 #include <ir0/copy_user.h>
@@ -123,6 +124,9 @@ int fd_can_read_for(process_t *proc, int fd)
   if (fd_table[fd].is_socket && fd_table[fd].vfs_file &&
       sock_stream_is(fd_table[fd].vfs_file))
     return sock_stream_poll_readable((struct sock_stream *)fd_table[fd].vfs_file);
+  if (fd_table[fd].is_socket && fd_table[fd].vfs_file &&
+      sock_icmp_is(fd_table[fd].vfs_file))
+    return sock_icmp_poll_readable((struct sock_icmp *)fd_table[fd].vfs_file);
   if (fd_table[fd].is_eventfd && fd_table[fd].vfs_file)
     return ir0_eventfd_poll_readable((struct ir0_eventfd *)fd_table[fd].vfs_file);
   if (fd_table[fd].is_timerfd && fd_table[fd].vfs_file)
@@ -1213,6 +1217,8 @@ int64_t sys_close(int fd)
     {
       if (sock_stream_is(fd_table[fd].vfs_file))
         sock_stream_release((struct sock_stream *)fd_table[fd].vfs_file);
+      else if (sock_icmp_is(fd_table[fd].vfs_file))
+        sock_icmp_release((struct sock_icmp *)fd_table[fd].vfs_file);
       else if (!sock_stream_is_slot(fd_table[fd].vfs_file))
         sock_udp_release((struct sock_udp *)fd_table[fd].vfs_file);
       fd_table[fd].vfs_file = NULL;
@@ -1424,6 +1430,16 @@ int64_t sys_dup2(int oldfd, int newfd)
       ir0_timerfd_release((struct ir0_timerfd *)fd_table[newfd].vfs_file);
       fd_table[newfd].vfs_file = NULL;
     }
+    else if (fd_table[newfd].is_socket && fd_table[newfd].vfs_file)
+    {
+      if (sock_stream_is(fd_table[newfd].vfs_file))
+	sock_stream_release((struct sock_stream *)fd_table[newfd].vfs_file);
+      else if (sock_icmp_is(fd_table[newfd].vfs_file))
+	sock_icmp_release((struct sock_icmp *)fd_table[newfd].vfs_file);
+      else if (!sock_stream_is_slot(fd_table[newfd].vfs_file))
+	sock_udp_release((struct sock_udp *)fd_table[newfd].vfs_file);
+      fd_table[newfd].vfs_file = NULL;
+    }
     else if (fd_table[newfd].vfs_file)
     {
       vfs_close((struct vfs_file *)fd_table[newfd].vfs_file);
@@ -1511,6 +1527,20 @@ int64_t sys_dup2(int oldfd, int newfd)
   else if (fd_table[oldfd].is_timerfd && fd_table[oldfd].vfs_file)
   {
     ir0_timerfd_acquire((struct ir0_timerfd *)fd_table[oldfd].vfs_file);
+    fd_table[newfd].vfs_file = fd_table[oldfd].vfs_file;
+  }
+  else if (fd_table[oldfd].is_socket && fd_table[oldfd].vfs_file)
+  {
+    /*
+     * BusyBox ping does xmove_fd(raw_sock, 0). Must not vfs_file_acquire the
+     * sock_* object — that corrupts magic and sendto falls through as UDP.
+     */
+    if (sock_stream_is(fd_table[oldfd].vfs_file))
+      sock_stream_acquire((struct sock_stream *)fd_table[oldfd].vfs_file);
+    else if (sock_icmp_is(fd_table[oldfd].vfs_file))
+      sock_icmp_acquire((struct sock_icmp *)fd_table[oldfd].vfs_file);
+    else if (!sock_stream_is_slot(fd_table[oldfd].vfs_file))
+      sock_udp_acquire((struct sock_udp *)fd_table[oldfd].vfs_file);
     fd_table[newfd].vfs_file = fd_table[oldfd].vfs_file;
   }
   else if (fd_table[oldfd].vfs_file)

--- a/kernel/syscalls/socket_syscalls.c
+++ b/kernel/syscalls/socket_syscalls.c
@@ -26,8 +26,10 @@
 #include <ir0/open_flags.h>
 #include <ir0/sock_udp.h>
 #include <ir0/sock_stream.h>
+#include <ir0/sock_icmp.h>
 #include <ir0/socket.h>
 #include <ir0/signals.h>
+#include <ir0/arch_cpu.h>
 #include <ir0/pipe.h>
 #include <ir0/vfs.h>
 #include <ir0/memfd.h>
@@ -104,6 +106,8 @@ static int sock_alloc_fd_flags(void *sock, int is_stream, int type_flags)
 	{
 		if (is_stream)
 			sock_stream_release(sock);
+		else if (sock_icmp_is(sock))
+			sock_icmp_release(sock);
 		else
 			sock_udp_release(sock);
 		return -EMFILE;
@@ -146,7 +150,27 @@ static struct sock_udp *sock_fd_lookup(int fd)
 	p = fd_table[fd].vfs_file;
 	if (sock_stream_is(p))
 		return NULL;
+	if (sock_icmp_is(p))
+		return NULL;
 	return (struct sock_udp *)p;
+}
+
+static struct sock_icmp *sock_icmp_fd_lookup(int fd)
+{
+	fd_entry_t *fd_table;
+	void *p;
+
+	if (!current_process)
+		return NULL;
+	if (fd < 0 || fd >= MAX_FDS_PER_PROCESS)
+		return NULL;
+	fd_table = get_process_fd_table();
+	if (!fd_table[fd].in_use || !fd_table[fd].is_socket)
+		return NULL;
+	p = fd_table[fd].vfs_file;
+	if (!sock_icmp_is(p))
+		return NULL;
+	return (struct sock_icmp *)p;
 }
 
 static struct sock_stream *sock_stream_fd_lookup(int fd)
@@ -206,6 +230,21 @@ int64_t sys_socket(int domain, int type, int protocol)
 			return -ENOMEM;
 		fd = sock_alloc_fd_flags(ss, 1, type_flags);
 		return fd < 0 ? fd : fd;
+	}
+
+	if (base == SOCK_RAW)
+	{
+		struct sock_icmp *icmp;
+
+		if (domain != AF_INET)
+			return -EAFNOSUPPORT;
+		if (protocol != 0 && protocol != IPPROTO_ICMP)
+			return -EPROTONOSUPPORT;
+		icmp = sock_icmp_create();
+		if (!icmp)
+			return -ENOMEM;
+		fd = sock_alloc_fd_flags(icmp, 0, type_flags);
+		return fd;
 	}
 
 	if (domain != AF_INET)
@@ -306,6 +345,7 @@ ssize_t sys_sendto(int fd, const void *buf, size_t len, int flags,
 	struct sock_stream *ss;
 	struct sockaddr_in sin;
 	struct sock_udp *sock;
+	struct sock_icmp *icmp;
 	uint8_t *kbuf;
 	int ret;
 
@@ -354,6 +394,25 @@ ssize_t sys_sendto(int fd, const void *buf, size_t len, int flags,
 	if (sin.sin_family != AF_INET)
 		return -EAFNOSUPPORT;
 
+	icmp = sock_icmp_fd_lookup(fd);
+	if (icmp)
+	{
+		kbuf = kmalloc(len);
+		if (!kbuf)
+			return -ENOMEM;
+		if (copy_from_user(kbuf, buf, len) != 0)
+		{
+			kfree(kbuf);
+			return -EFAULT;
+		}
+		ret = sock_icmp_sendto(icmp, sin.sin_addr, kbuf, len);
+		kfree(kbuf);
+		if (ret < 0)
+			return ret;
+		(void)flags;
+		return (ssize_t)ret;
+	}
+
 	sock = sock_fd_lookup(fd);
 	if (!sock)
 		return -ENOTSOCK;
@@ -380,6 +439,7 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 {
 	struct sock_stream *ss;
 	struct sock_udp *sock;
+	struct sock_icmp *icmp;
 	uint16_t src_port = 0;
 	uint8_t *kbuf;
 	ssize_t n;
@@ -470,6 +530,98 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 	{
 		if (validate_userspace_buffer(src_addr, out_len) != 0)
 			return -EFAULT;
+	}
+
+	icmp = sock_icmp_fd_lookup(fd);
+	if (icmp)
+	{
+		nb = sock_nonblock_fd(fd, flags);
+		kbuf = kmalloc(len);
+		if (!kbuf)
+			return -ENOMEM;
+
+		for (;;)
+		{
+			n = sock_icmp_recvfrom(icmp, kbuf, len, MSG_DONTWAIT,
+					       &src_ip_be);
+			if (n != -EAGAIN)
+				break;
+			if (nb)
+			{
+				kfree(kbuf);
+				return -EAGAIN;
+			}
+			if (signals_pause_should_interrupt(current_process))
+			{
+				handle_signals();
+				kfree(kbuf);
+				/*
+				 * Sysret would return to the insn after recvfrom and
+				 * ignore task.RIP. If a userspace handler was armed,
+				 * iretq into it (BusyBox ping SIGALRM → sendping4).
+				 */
+				if (current_process->saved_context)
+				{
+					process_restore_user_task_segments(current_process);
+					switch_to_user_task(&current_process->task);
+				}
+				return -EINTR;
+			}
+			{
+				int64_t sleep_ret = syscall_sleep_ms_locked(20);
+
+				if (sleep_ret < 0)
+				{
+					kfree(kbuf);
+					return sleep_ret;
+				}
+			}
+			if (signals_pause_should_interrupt(current_process))
+			{
+				handle_signals();
+				kfree(kbuf);
+				if (current_process->saved_context)
+				{
+					process_restore_user_task_segments(current_process);
+					switch_to_user_task(&current_process->task);
+				}
+				return -EINTR;
+			}
+			icmp = sock_icmp_fd_lookup(fd);
+			if (!icmp)
+			{
+				kfree(kbuf);
+				return -EBADF;
+			}
+		}
+		if (n < 0)
+		{
+			kfree(kbuf);
+			return n;
+		}
+		if (copy_to_user(buf, kbuf, (size_t)n) != 0)
+		{
+			kfree(kbuf);
+			return -EFAULT;
+		}
+		kfree(kbuf);
+
+		if (src_addr && out_len >= sizeof(sin))
+		{
+			memset(&sin, 0, sizeof(sin));
+			sin.sin_family = AF_INET;
+			sin.sin_addr = src_ip_be;
+			if (copy_to_user(src_addr, &sin, sizeof(sin)) != 0)
+				return -EFAULT;
+			if (addrlen)
+			{
+				socklen_t slen = sizeof(sin);
+
+				if (copy_to_user(addrlen, &slen, sizeof(slen)) != 0)
+					return -EFAULT;
+			}
+		}
+		return n;
 	}
 
 	sock = sock_fd_lookup(fd);
@@ -741,6 +893,8 @@ static void scm_rights_dtor(void *entry, size_t sz)
 	{
 		if (sock_stream_is(e->vfs_file))
 			sock_stream_release((struct sock_stream *)e->vfs_file);
+		else if (sock_icmp_is(e->vfs_file))
+			sock_icmp_release((struct sock_icmp *)e->vfs_file);
 		else if (!sock_stream_is_slot(e->vfs_file))
 			sock_udp_release((struct sock_udp *)e->vfs_file);
 	}
@@ -789,6 +943,8 @@ static int scm_clone_fd_entry(fd_entry_t *dst, int srcfd)
 	{
 		if (sock_stream_is(dst->vfs_file))
 			sock_stream_acquire((struct sock_stream *)dst->vfs_file);
+		else if (sock_icmp_is(dst->vfs_file))
+			sock_icmp_acquire((struct sock_icmp *)dst->vfs_file);
 		else if (!sock_stream_is_slot(dst->vfs_file))
 			sock_udp_acquire((struct sock_udp *)dst->vfs_file);
 	}

--- a/kernel/syscalls/syscall_dispatch.c
+++ b/kernel/syscalls/syscall_dispatch.c
@@ -219,6 +219,7 @@ WRAP0(sys_sync)
 WRAP2(sys_gettimeofday, struct timeval *, void *)
 WRAP2(sys_getitimer, int, struct itimerval *)
 WRAP3(sys_setitimer, int, const struct itimerval *, struct itimerval *)
+WRAP1(sys_alarm, unsigned int)
 WRAP5(sys_prctl, int, unsigned long, unsigned long, unsigned long, unsigned long)
 WRAP1(sys_setuid, uid_t)
 WRAP1(sys_setgid, gid_t)
@@ -324,6 +325,7 @@ void syscall_table_init(void)
   syscall_table_rw[__NR_dup2]           = wrap_sys_dup2;
   syscall_table_rw[__NR_nanosleep]      = wrap_sys_nanosleep;
   syscall_table_rw[__NR_getitimer]      = wrap_sys_getitimer;
+  syscall_table_rw[__NR_alarm]          = wrap_sys_alarm;
   syscall_table_rw[__NR_setitimer]      = wrap_sys_setitimer;
   syscall_table_rw[__NR_pause]          = wrap_sys_pause;
   syscall_table_rw[__NR_getpid]         = wrap_sys_getpid;

--- a/kernel/syscalls/time_syscalls.c
+++ b/kernel/syscalls/time_syscalls.c
@@ -7,7 +7,7 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: time_syscalls.c
- * Description: time syscalls (gettimeofday, clock_gettime)
+ * Description: time syscalls (gettimeofday, clock_gettime, setitimer)
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -20,6 +20,81 @@
 #include <ir0/clock.h>
 #include <ir0/copy_user.h>
 #include <ir0/validation.h>
+#include <ir0/signals.h>
+#include <ir0/time.h>
+#include <string.h>
+
+extern process_t *process_list;
+
+static uint64_t timeval_to_ms(const struct timeval *tv)
+{
+	uint64_t ms;
+
+	if (!tv || (tv->tv_sec == 0 && tv->tv_usec == 0))
+		return 0;
+	if (tv->tv_sec < 0 || tv->tv_usec < 0)
+		return 0;
+	ms = (uint64_t)tv->tv_sec * 1000UL;
+	ms += (uint64_t)tv->tv_usec / 1000UL;
+	if (ms == 0 && (tv->tv_sec > 0 || tv->tv_usec > 0))
+		ms = 1; /* sub-ms → one tick */
+	return ms;
+}
+
+static void ms_to_timeval(uint64_t ms, struct timeval *tv)
+{
+	if (!tv)
+		return;
+	tv->tv_sec = (time_t)(ms / 1000UL);
+	tv->tv_usec = (suseconds_t)((ms % 1000UL) * 1000UL);
+}
+
+static void itimer_fill_old(process_t *p, uint64_t now, struct itimerval *old)
+{
+	uint64_t rem = 0;
+
+	memset(old, 0, sizeof(*old));
+	if (p->it_real_expire_ms != 0)
+	{
+		if (p->it_real_expire_ms > now)
+			rem = p->it_real_expire_ms - now;
+		else
+			rem = 1;
+	}
+	ms_to_timeval(rem, &old->it_value);
+	ms_to_timeval(p->it_real_interval_ms, &old->it_interval);
+}
+
+/*
+ * process_itimer_tick - Fire ITIMER_REAL expiries from the clock tick.
+ * Called from clock_tick(); may wake blocked tasks via send_signal().
+ */
+void process_itimer_tick(uint64_t now_ms)
+{
+	process_t *p;
+
+	for (p = process_list; p; p = p->next)
+	{
+		if (p->it_real_expire_ms == 0)
+			continue;
+		if (now_ms < p->it_real_expire_ms)
+			continue;
+
+		if (p->it_real_interval_ms != 0)
+		{
+			/* Catch up like timerfd: advance by whole intervals. */
+			do
+			{
+				p->it_real_expire_ms += p->it_real_interval_ms;
+			} while (p->it_real_expire_ms <= now_ms &&
+				 p->it_real_interval_ms != 0);
+		}
+		else
+			p->it_real_expire_ms = 0;
+
+		(void)send_signal((int)p->task.pid, SIGALRM);
+	}
+}
 
 int64_t sys_gettimeofday(struct timeval *tv, void *tz)
 {
@@ -90,24 +165,113 @@ int64_t sys_clock_gettime(int clock_id, struct timespec *tp)
 	return 0;
 }
 
-/*
- * getitimer/setitimer — honest ENOSYS until SIGALRM delivery exists.
- * TinyX SmartSchedule probes setitimer; on failure it sets
- * SmartScheduleDisable and continues on poll/select (desired).
- * Returning success without timers caused glibc stack-canary abort in X.
- */
 int64_t sys_getitimer(int which, struct itimerval *curr_value)
 {
-	(void)which;
-	(void)curr_value;
-	return -ENOSYS;
+	struct itimerval old;
+	uint64_t now;
+
+	if (!current_process)
+		return -ESRCH;
+	if (which != ITIMER_REAL)
+		return -EINVAL;
+	if (!curr_value)
+		return -EFAULT;
+	if (validate_userspace_buffer(curr_value, sizeof(struct itimerval)) != 0)
+		return -EFAULT;
+
+	now = clock_get_uptime_milliseconds();
+	itimer_fill_old(current_process, now, &old);
+	if (copy_to_user(curr_value, &old, sizeof(old)) != 0)
+		return -EFAULT;
+	return 0;
 }
 
 int64_t sys_setitimer(int which, const struct itimerval *new_value,
 		      struct itimerval *old_value)
 {
-	(void)which;
-	(void)new_value;
-	(void)old_value;
-	return -ENOSYS;
+	struct itimerval kval;
+	struct itimerval old;
+	uint64_t now;
+	uint64_t value_ms;
+	uint64_t interval_ms;
+
+	if (!current_process)
+		return -ESRCH;
+	if (which != ITIMER_REAL)
+		return -EINVAL;
+
+	now = clock_get_uptime_milliseconds();
+	itimer_fill_old(current_process, now, &old);
+
+	if (old_value)
+	{
+		if (validate_userspace_buffer(old_value, sizeof(struct itimerval)) != 0)
+			return -EFAULT;
+		if (copy_to_user(old_value, &old, sizeof(old)) != 0)
+			return -EFAULT;
+	}
+
+	if (!new_value)
+		return 0;
+
+	if (validate_userspace_buffer((void *)new_value, sizeof(struct itimerval)) != 0)
+		return -EFAULT;
+	if (copy_from_user(&kval, new_value, sizeof(kval)) != 0)
+		return -EFAULT;
+
+	if (kval.it_value.tv_usec >= 1000000 || kval.it_value.tv_usec < 0 ||
+	    kval.it_interval.tv_usec >= 1000000 || kval.it_interval.tv_usec < 0 ||
+	    kval.it_value.tv_sec < 0 || kval.it_interval.tv_sec < 0)
+		return -EINVAL;
+
+	value_ms = timeval_to_ms(&kval.it_value);
+	interval_ms = timeval_to_ms(&kval.it_interval);
+
+	if (value_ms == 0)
+	{
+		current_process->it_real_expire_ms = 0;
+		current_process->it_real_interval_ms = 0;
+	}
+	else
+	{
+		current_process->it_real_expire_ms = now + value_ms;
+		current_process->it_real_interval_ms = interval_ms;
+	}
+	return 0;
+}
+
+/*
+ * alarm(2) — one-shot ITIMER_REAL in whole seconds (musl may use setitimer).
+ * Returns previous remaining seconds (rounded up), like Linux.
+ */
+int64_t sys_alarm(unsigned int seconds)
+{
+	struct itimerval old;
+	struct itimerval neu;
+	uint64_t now;
+	uint64_t rem_ms;
+	unsigned int prev;
+
+	if (!current_process)
+		return -ESRCH;
+
+	now = clock_get_uptime_milliseconds();
+	itimer_fill_old(current_process, now, &old);
+	rem_ms = timeval_to_ms(&old.it_value);
+	prev = (unsigned int)((rem_ms + 999UL) / 1000UL);
+
+	memset(&neu, 0, sizeof(neu));
+	neu.it_value.tv_sec = (time_t)seconds;
+	if (seconds == 0)
+	{
+		current_process->it_real_expire_ms = 0;
+		current_process->it_real_interval_ms = 0;
+	}
+	else
+	{
+		current_process->it_real_expire_ms = now + (uint64_t)seconds * 1000UL;
+		current_process->it_real_interval_ms = 0;
+	}
+	(void)neu;
+	return (int64_t)prev;
 }

--- a/kernel/syscalls/time_syscalls.h
+++ b/kernel/syscalls/time_syscalls.h
@@ -22,3 +22,7 @@ int64_t sys_clock_gettime(int clock_id, struct timespec *tp);
 int64_t sys_getitimer(int which, struct itimerval *curr_value);
 int64_t sys_setitimer(int which, const struct itimerval *new_value,
 		      struct itimerval *old_value);
+int64_t sys_alarm(unsigned int seconds);
+
+/* Called from clock_tick — fire ITIMER_REAL → SIGALRM. */
+void process_itimer_tick(uint64_t now_ms);

--- a/net/icmp.c
+++ b/net/icmp.c
@@ -13,6 +13,7 @@
 
 #include "icmp.h"
 #include "ip.h"
+#include <ir0/sock_icmp.h>
 #include <ir0/kmem.h>
 #include <ir0/logging.h>
 #include <ir0/clock.h>
@@ -218,6 +219,15 @@ void icmp_receive_handler(struct net_device *dev, const void *data,
 
     LOG_INFO_FMT("ICMP", "Received ICMP packet: type=%d, code=%d", 
                  (int)type, (int)code);
+
+    /*
+     * Deliver to SOCK_RAW IPPROTO_ICMP sockets (BusyBox ping). Skip echo
+     * requests: the kernel auto-replies and userspace did not send them.
+     */
+    if (type != ICMP_TYPE_ECHO_REQUEST)
+        sock_icmp_rx_deliver((uint32_t)src_ip,
+                             (uint32_t)(rx_ctx ? rx_ctx->dest_addr : 0),
+                             rx_ttl, data, len);
 
     switch (type)
     {

--- a/net/ip.c
+++ b/net/ip.c
@@ -806,3 +806,24 @@ int ip_route_del(ip4_addr_t dest_network, ip4_addr_t netmask)
     return -1;
 }
 
+/**
+ * ip_route_walk - Invoke @cb for each entry in the software route list.
+ * Does not synthesize the connected/default routes from globals (caller does).
+ */
+int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
+			     void *ctx),
+		  void *ctx)
+{
+	struct ip_route_entry *route;
+
+	if (!cb)
+		return -EINVAL;
+
+	for (route = ip_routes; route; route = route->next)
+	{
+		if (cb(route->dest_network, route->netmask, route->gateway, ctx) != 0)
+			return -1;
+	}
+	return 0;
+}
+

--- a/net/ip.h
+++ b/net/ip.h
@@ -65,6 +65,9 @@ void ip_receive_handler(struct net_device *dev, const void *data,
 /* Routing API */
 int ip_route_add(ip4_addr_t dest_network, ip4_addr_t netmask, ip4_addr_t gateway);
 int ip_route_del(ip4_addr_t dest_network, ip4_addr_t netmask);
+int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
+			     void *ctx),
+		  void *ctx);
 
 /* IP Address Utilities */
 static inline ip4_addr_t ip_make_addr(uint8_t a, uint8_t b, uint8_t c, uint8_t d)


### PR DESCRIPTION
## Summary
- SOCK_RAW/IPPROTO_ICMP para BusyBox `ping` (RX con cabecera IP)
- `setitimer`/`alarm` ITIMER_REAL + tick → SIGALRM
- `/proc/net/route` para `route -n` / `netstat -rn`
- Matriz de red actualizada; smoke QEMU `NET_P0_SMOKE_OK`

## Test plan
- [x] `make kernel-x64.bin` + `arch-guard`
- [x] QEMU user-net: ifconfig, ping -c 2 -A, route/netstat, applets nc/wget/nslookup

## Notas
- `ping -c N` sin `-A` sigue limitado (SIGALRM mid-syscall / sysret)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches syscall surface (timers, raw sockets, signal delivery from recvfrom), FD lifecycle, and procfs networking output; behavior is security- and ABI-sensitive but scoped to networking/timer paths with documented ping limitations.
> 
> **Overview**
> Enables **BusyBox `ping` and routing tools** on QEMU user-net by filling gaps that were previously stubbed or missing from the product matrix.
> 
> **`AF_INET` `SOCK_RAW` / `IPPROTO_ICMP`** is implemented end-to-end: `socket`/`sendto`/`recvfrom`, poll when RX is queued, and delivery from the ICMP stack with **IP header + ICMP** (Linux ABI). ICMP echo requests are still handled in-kernel; replies go to raw sockets. FD table paths (`dup`, `close`, `xmove_fd`) treat ICMP sockets like other sock types so ping’s fd shuffle does not corrupt socket magic.
> 
> **`setitimer`/`getitimer`/`alarm` for `ITIMER_REAL`** replace the old `ENOSYS` stubs: per-process expiry state on the clock tick fires **SIGALRM** (with fork clearing timers). **`SIGALRM`** is included in default-terminate signal handling. **`recvfrom` on raw ICMP** can iretq into a userspace handler when a signal arrives mid-wait (partial fix for alarm-driven ping; **`ping -c N` without `-A`** still needs SIGALRM during syscall return via sysret).
> 
> **`/proc/net/route`** exposes Linux-style rows via `ip_route_walk`, synthesizing connected/default routes from globals when the soft table is empty. Docs update the networking matrix and recorded smokes (`ifconfig`, `ping -c 2 -A`, `route`/`netstat`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8684316c54c974a87a3bedb8851f372e935801f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->