### PR TITLE
feat(net): connect interrumpible, FIB soft y filas /proc/net

### DIFF
--- a/Documentation/releases/NETWORKING_MATRIX.md
+++ b/Documentation/releases/NETWORKING_MATRIX.md
@@ -1,12 +1,12 @@
 # Networking capability matrix (lista §9)
 
-> **Última verificación:** 2026-07-29  
+> **Última verificación:** 2026-07-30  
 > **Fuente de verdad:** código kernel + ISD BusyBox; smokes QEMU user-net (`rtl8139`).
 
 | capacidad | implementada | probada | limitación | herramienta |
 |-----------|--------------|---------|------------|-------------|
 | socket(AF_INET, SOCK_DGRAM) | sí | parcial (smokes UDP) | — | `nc` (ISD) |
-| socket(AF_INET, SOCK_STREAM) | sí | parcial (TCP smokes) | connect timeout userspace incompleto | `nc` / `wget` |
+| socket(AF_INET, SOCK_STREAM) | sí | parcial | connect interrumpible por SIGALRM (`nc -w`) | `nc` / `wget` |
 | socket(AF_INET, SOCK_RAW, ICMP) | sí | sí | RX = IP+ICMP (Linux ABI) | `ping` |
 | bind / connect | sí | parcial | — | — |
 | listen / accept | sí | parcial | — | — |
@@ -15,29 +15,28 @@
 | poll on SOCK_RAW ICMP | sí | smoke path | readable iff RX queued | — |
 | SIOCGIF* ioctls | sí | sí | read-mostly | `ifconfig -a` |
 | /proc/net/dev | sí | parcial | — | — |
-| /proc/net/route | sí | sí | sintetiza connected+default si la tabla soft está vacía | `route -n`, `netstat -rn` |
-| /proc/net/{tcp,udp,raw,unix} | sí (stub) | sí | cabecera Linux vacía (sin filas) | `netstat` |
+| /proc/net/route | sí | sí | soft FIB sembrada desde `ip_init`/DHCP/`NET_SET_CONFIG` | `route -n`, `netstat -rn` |
+| /proc/net/{tcp,udp,raw,unix} | sí | sí | filas desde inventarios sock_*; inode = puntero | `netstat` |
 | /proc/netinfo | sí | parcial | TSV raw | — |
-| setitimer(ITIMER_REAL) / alarm | sí | sí | SIGALRM: restorer + `rt_sigreturn` + frame 16-aligned; `signal_enter_pending` evita reentrada | BusyBox ping |
+| setitimer(ITIMER_REAL) / alarm | sí | sí | SIGALRM mid-syscall + connect wait | BusyBox ping / nc |
 | IPv4 + ICMP echo | sí | sí | QEMU user-net `10.0.2.15` → `10.0.2.2` | `ping` |
-| UDP / TCP | sí | parcial | TCP connect a puerto cerrado puede colgar `-w` | — |
+| UDP / TCP | sí | parcial | TCP async/`EINPROGRESS` no | — |
 | DNS | parcial | sí (L7) | QEMU user DNS `10.0.2.3` | `nslookup` |
 | virtio-net / RTL8139 | sí | smoke | — | — |
 | AF_NETLINK / ip(8) | **no** | — | no fingir netlink | — |
 | DHCP client userspace | bloqueado | — | — | `udhcpc` off |
 
-## Smokes verificados (2026-07-29)
+## Smokes verificados (2026-07-30)
 
 | Smoke | Resultado |
 |-------|-----------|
 | `ifconfig -a` | PASS — `eth0` `10.0.2.15` |
-| `ping -c 2 -A 10.0.2.2` | PASS — 2 RTT, 0% loss, `ttl=255` |
-| `ping -c 2 -W 3 10.0.2.2` (sin `-A`) | PASS — 10/10; SIGALRM mid-recvfrom OK |
-| `route -n` / `netstat -rn` | PASS — lee `/proc/net/route` |
-| `netstat` (default) | PASS — `/proc/net/{tcp,udp,raw,unix}` stub (sin “No such file”) |
-| `nslookup 10.0.2.2 10.0.2.3` | PASS — Server/Address vía DNS user-net |
-| `nc -w 2 10.0.2.2 80` | FAIL / hang — connect TCP sin progreso de timeout |
-| `wget http://10.0.2.2/` | FAIL — SEGV userspace (TCP/HTTP path) |
+| `ping -c 2 -A` / `ping -c 2 -W 3` | PASS |
+| `route -n` / `netstat -rn` | PASS — soft FIB |
+| `netstat` | PASS — filas tcp/udp/raw/unix cuando hay sockets |
+| `nslookup 10.0.2.2 10.0.2.3` | PASS |
+| `nc -w 2 10.0.2.2 9` | PASS — sale por alarm/EINTR (no hang) |
+| `wget http://10.0.2.2/` | parcial — connect ya no cuelga eterno; HTTP path puede fallar |
 
 ## ISD BusyBox (`ir0_full`)
 
@@ -45,6 +44,6 @@ Habilitados: `IFCONFIG`, `PING`, `ROUTE`, `NETSTAT`, `NSLOOKUP`, `NC`, `WGET` (s
 
 ## Pendiente explícito
 
-1. Timeout de `connect` / poll TCP para `nc -w` y `wget` sin colgar ni SEGV.
-2. Sembrar `ip_route_add` desde `ip_init`/DHCP para alinear lista soft y `/proc/net/route`.
-3. Rellenar filas reales en `/proc/net/{tcp,udp,…}` (hoy solo cabecera).
+1. TCP no bloqueante (`EINPROGRESS` + `poll` POLLOUT) y `SO_SNDTIMEO`/`SO_RCVTIMEO` si hace falta para wget HTTP completo.
+2. Estados TCP finos (SYN_SENT, etc.) en `/proc/net/tcp` (hoy: idle/listen/connected aproximados).
+3. SEGV al salir de pid1 tras applets BusyBox (post-smoke; no bloquea connect/route/netstat).

--- a/fs/devfs.c
+++ b/fs/devfs.c
@@ -1362,6 +1362,7 @@ int64_t dev_net_ioctl(devfs_entry_t *entry, uint64_t request, void *arg)
                             dev = dev->next;
                         }
                     }
+                    (void)ip_routes_seed_from_globals();
                     return 0;
                 }
             }

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -46,6 +46,9 @@
 #include <ir0/resource_registry.h>
 #include <ir0/pseudo_fs.h>
 #include <ir0/logging.h>
+#include <ir0/sock_stream.h>
+#include <ir0/sock_udp.h>
+#include <ir0/sock_icmp.h>
 
 #define PROC_BUFFER_SIZE           4096    /* Standard proc buffer size */
 #define PROC_LINE_MAX_LEN          256     /* Max line length for parsing */
@@ -278,16 +281,165 @@ static int proc_route_walk_cb(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
 #endif
 
 /*
- * Empty Linux-style socket tables so BusyBox netstat does not fail open().
- * Rows can be filled later from sock_stream / sock_udp inventories.
+ * Linux-style /proc/net/{tcp,udp,raw,unix} for BusyBox netstat.
+ * IPv4 addresses are printed as %08X of the __be32 (sin_addr.s_addr) value —
+ * same as Linux get_tcp4_sock — not ntohl()'d host integers.
  */
-static int proc_net_socktable_empty(char *buf, size_t count, const char *header)
+struct proc_sock_fmt_ctx
+{
+	char *buf;
+	size_t count;
+	size_t off;
+	int sl;
+	int err;
+};
+
+static int proc_sock_append(struct proc_sock_fmt_ctx *c, const char *line)
+{
+	size_t n;
+	size_t avail;
+
+	if (!c || !line || c->err)
+		return -1;
+	n = strlen(line);
+	avail = (c->off < c->count) ? (c->count - c->off) : 0;
+	if (avail <= 1)
+	{
+		c->err = 1;
+		return -1;
+	}
+	if (n >= avail)
+		n = avail - 1;
+	memcpy(c->buf + c->off, line, n);
+	c->off += n;
+	c->buf[c->off] = '\0';
+	return 0;
+}
+
+static int proc_inet_row_cb(const struct sock_stream_inet_snap *s, void *ctx)
+{
+	struct proc_sock_fmt_ctx *c = ctx;
+	char line[192];
+	int n;
+
+	n = snprintf(line, sizeof(line),
+		     "%4d: %08X:%04X %08X:%04X %02X %08X:%08X %02X:%08X %08X %5u %8d %lu %d\n",
+		     c->sl++,
+		     (unsigned)s->local_ip, (unsigned)s->local_port,
+		     (unsigned)s->rem_ip, (unsigned)s->rem_port,
+		     (unsigned)s->st,
+		     0u, 0u, 0u, 0u, 0u, 0u, 0, (unsigned long)s->inode, 1);
+	if (n < 0)
+		return -1;
+	return proc_sock_append(c, line);
+}
+
+static int proc_udp_row_cb(const struct sock_udp_snap *s, void *ctx)
+{
+	struct proc_sock_fmt_ctx *c = ctx;
+	char line[192];
+	int n;
+
+	n = snprintf(line, sizeof(line),
+		     "%4d: %08X:%04X %08X:%04X %02X %08X:%08X %02X:%08X %08X %5u %8d %lu %d\n",
+		     c->sl++,
+		     (unsigned)s->local_ip, (unsigned)s->local_port,
+		     (unsigned)s->rem_ip, (unsigned)s->rem_port,
+		     (unsigned)s->st,
+		     0u, 0u, 0u, 0u, 0u, 0u, 0, (unsigned long)s->inode, 1);
+	if (n < 0)
+		return -1;
+	return proc_sock_append(c, line);
+}
+
+static int proc_raw_row_cb(const struct sock_icmp_snap *s, void *ctx)
+{
+	struct proc_sock_fmt_ctx *c = ctx;
+	char line[192];
+	int n;
+
+	n = snprintf(line, sizeof(line),
+		     "%4d: %08X:%04X %08X:%04X %02X %08X:%08X %02X:%08X %08X %5u %8d %lu %d\n",
+		     c->sl++,
+		     0u, (unsigned)s->proto,
+		     0u, 0u,
+		     0x07u,
+		     0u, 0u, 0u, 0u, 0u, 0u, 0, (unsigned long)s->inode, 1);
+	if (n < 0)
+		return -1;
+	return proc_sock_append(c, line);
+}
+
+static int proc_unix_row_cb(const struct sock_stream_unix_snap *s, void *ctx)
+{
+	struct proc_sock_fmt_ctx *c = ctx;
+	char line[256];
+	char path[128];
+	int n;
+
+	path[0] = '\0';
+	if (s->path_len > 0)
+	{
+		if (s->is_abstract)
+		{
+			path[0] = '@';
+			if (s->path_len < sizeof(path) - 1)
+			{
+				memcpy(path + 1, s->path, s->path_len);
+				path[s->path_len + 1] = '\0';
+			}
+		}
+		else if (s->path_len < sizeof(path))
+		{
+			memcpy(path, s->path, s->path_len);
+			path[s->path_len] = '\0';
+		}
+	}
+
+	n = snprintf(line, sizeof(line),
+		     "%08lX: %08X %08X %08X %04X %02X %5lu",
+		     (unsigned long)s->inode,
+		     (unsigned)s->refcnt,
+		     0u, 0u,
+		     (unsigned)s->type,
+		     (unsigned)s->st,
+		     (unsigned long)s->inode);
+	if (n < 0)
+		return -1;
+	if (path[0])
+	{
+		size_t used = (size_t)n;
+
+		if (used + 2 < sizeof(line))
+		{
+			line[used++] = ' ';
+			strncpy(line + used, path, sizeof(line) - used - 2);
+			line[sizeof(line) - 2] = '\0';
+		}
+	}
+	{
+		size_t L = strlen(line);
+
+		if (L + 1 < sizeof(line))
+		{
+			line[L] = '\n';
+			line[L + 1] = '\0';
+		}
+	}
+	return proc_sock_append(c, line);
+}
+
+static int proc_net_socktable_start(char *buf, size_t count, const char *header,
+				    struct proc_sock_fmt_ctx *c)
 {
 	int n;
 
 	if (VALIDATE_BUFFER(buf, count) != 0)
 		return -1;
 	memset(buf, 0, count);
+	memset(c, 0, sizeof(*c));
+	c->buf = buf;
+	c->count = count;
 	if (!header)
 		return 0;
 	n = snprintf(buf, count, "%s", header);
@@ -296,37 +448,65 @@ static int proc_net_socktable_empty(char *buf, size_t count, const char *header)
 	if ((size_t)n >= count)
 	{
 		buf[count - 1] = '\0';
-		return (int)(count - 1);
+		c->off = count - 1;
+		return (int)c->off;
 	}
-	return n;
+	c->off = (size_t)n;
+	return 0;
 }
 
 int proc_net_tcp_read(char *buf, size_t count)
 {
-	return proc_net_socktable_empty(
-		buf, count,
-		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n");
+	struct proc_sock_fmt_ctx c;
+	const char *hdr =
+		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n";
+
+	if (proc_net_socktable_start(buf, count, hdr, &c) < 0)
+		return -1;
+#if CONFIG_ENABLE_NETWORKING
+	(void)sock_stream_inet_walk(proc_inet_row_cb, &c);
+#endif
+	return (int)c.off;
 }
 
 int proc_net_udp_read(char *buf, size_t count)
 {
-	return proc_net_socktable_empty(
-		buf, count,
-		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n");
+	struct proc_sock_fmt_ctx c;
+	const char *hdr =
+		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n";
+
+	if (proc_net_socktable_start(buf, count, hdr, &c) < 0)
+		return -1;
+#if CONFIG_ENABLE_NETWORKING
+	(void)sock_udp_walk(proc_udp_row_cb, &c);
+#endif
+	return (int)c.off;
 }
 
 int proc_net_raw_read(char *buf, size_t count)
 {
-	return proc_net_socktable_empty(
-		buf, count,
-		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n");
+	struct proc_sock_fmt_ctx c;
+	const char *hdr =
+		"  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode\n";
+
+	if (proc_net_socktable_start(buf, count, hdr, &c) < 0)
+		return -1;
+#if CONFIG_ENABLE_NETWORKING
+	(void)sock_icmp_walk(proc_raw_row_cb, &c);
+#endif
+	return (int)c.off;
 }
 
 int proc_net_unix_read(char *buf, size_t count)
 {
-	return proc_net_socktable_empty(
-		buf, count,
-		"Num       RefCount Protocol Flags    Type St Inode Path\n");
+	struct proc_sock_fmt_ctx c;
+	const char *hdr =
+		"Num       RefCount Protocol Flags    Type St Inode Path\n";
+
+	if (proc_net_socktable_start(buf, count, hdr, &c) < 0)
+		return -1;
+	(void)sock_stream_unix_walk(proc_unix_row_cb, &c);
+	return (int)c.off;
 }
 
 int proc_net_route_read(char *buf, size_t count)

--- a/includes/ir0/net.h
+++ b/includes/ir0/net.h
@@ -166,6 +166,8 @@ extern ip4_addr_t ip_gateway;
 int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
 			     void *ctx),
 		  void *ctx);
+int ip_route_add(ip4_addr_t dest_network, ip4_addr_t netmask, ip4_addr_t gateway);
+int ip_routes_seed_from_globals(void);
 
 /* ICMP helpers used by /dev/net control plane. */
 bool icmp_get_next_echo_result(uint16_t id, uint16_t *seq_out, uint64_t *rtt_out,

--- a/includes/ir0/sock_icmp.h
+++ b/includes/ir0/sock_icmp.h
@@ -39,3 +39,13 @@ ssize_t sock_icmp_recvfrom(struct sock_icmp *sock, void *buf, size_t len,
  */
 void sock_icmp_rx_deliver(uint32_t src_ip_be, uint32_t dst_ip_be, uint8_t ttl,
 			  const void *icmp_data, size_t icmp_len);
+
+struct sock_icmp_snap
+{
+	uint16_t proto; /* IPPROTO_ICMP = 1 as "port" */
+	unsigned long inode;
+	unsigned refcnt;
+};
+
+int sock_icmp_walk(int (*cb)(const struct sock_icmp_snap *s, void *ctx),
+		   void *ctx);

--- a/includes/ir0/sock_stream.h
+++ b/includes/ir0/sock_stream.h
@@ -61,3 +61,32 @@ int sock_stream_buf_space(const struct sock_stream *peer_of_sender);
 int sock_stream_buf_count(const struct sock_stream *s);
 int sock_stream_is_recv_shutdown(const struct sock_stream *s);
 struct sock_stream *sock_stream_get_peer(struct sock_stream *s);
+
+/* /proc/net/{tcp,unix} inventory (BusyBox netstat). */
+struct sock_stream_inet_snap
+{
+	uint32_t local_ip;
+	uint16_t local_port;
+	uint32_t rem_ip;
+	uint16_t rem_port;
+	uint8_t st; /* Linux tcp_state hex */
+	unsigned long inode;
+};
+
+struct sock_stream_unix_snap
+{
+	unsigned long inode;
+	unsigned refcnt;
+	uint8_t type; /* SOCK_STREAM = 1 */
+	uint8_t st;   /* 01 connected, 0A listen, 07 unbound-ish */
+	char path[108];
+	size_t path_len;
+	int is_abstract;
+};
+
+int sock_stream_inet_walk(int (*cb)(const struct sock_stream_inet_snap *s,
+				    void *ctx),
+			  void *ctx);
+int sock_stream_unix_walk(int (*cb)(const struct sock_stream_unix_snap *s,
+				    void *ctx),
+			  void *ctx);

--- a/includes/ir0/sock_udp.h
+++ b/includes/ir0/sock_udp.h
@@ -31,3 +31,15 @@ int sock_udp_sendto(struct sock_udp *sock, uint32_t dest_ip_be, uint16_t dest_po
 		    const void *data, size_t len);
 ssize_t sock_udp_recvfrom(struct sock_udp *sock, void *buf, size_t len, int flags,
 			  uint32_t *src_ip_be_out, uint16_t *src_port_out);
+
+struct sock_udp_snap
+{
+	uint32_t local_ip;
+	uint16_t local_port;
+	uint32_t rem_ip;
+	uint16_t rem_port;
+	uint8_t st;
+	unsigned long inode;
+};
+
+int sock_udp_walk(int (*cb)(const struct sock_udp_snap *s, void *ctx), void *ctx);

--- a/kernel/sock_icmp.c
+++ b/kernel/sock_icmp.c
@@ -356,3 +356,32 @@ ssize_t sock_icmp_recvfrom(struct sock_icmp *sock, void *buf, size_t len,
 	return (ssize_t)copy_len;
 #endif
 }
+
+int sock_icmp_walk(int (*cb)(const struct sock_icmp_snap *s, void *ctx),
+		   void *ctx)
+{
+	struct sock_icmp *s;
+	struct sock_icmp_snap snap;
+	uint64_t flags;
+
+	if (!cb)
+		return -EINVAL;
+
+	flags = sock_icmp_irq_save();
+	for (s = sock_icmp_open_list; s; s = s->list_next)
+	{
+		if (!sock_icmp_is(s))
+			continue;
+		memset(&snap, 0, sizeof(snap));
+		snap.proto = 1; /* IPPROTO_ICMP */
+		snap.inode = (unsigned long)(uintptr_t)s;
+		snap.refcnt = (unsigned)(s->refcount > 0 ? s->refcount : 1);
+		if (cb(&snap, ctx) != 0)
+		{
+			sock_icmp_irq_restore(flags);
+			return -1;
+		}
+	}
+	sock_icmp_irq_restore(flags);
+	return 0;
+}

--- a/kernel/sock_stream.c
+++ b/kernel/sock_stream.c
@@ -19,6 +19,7 @@
 
 #if CONFIG_ENABLE_NETWORKING
 #include "tcp.h"
+#include <ir0/net.h>
 #endif
 
 #define SS_BUF 4096
@@ -737,4 +738,92 @@ int sock_stream_set_reuseaddr(struct sock_stream *s, int on)
 int sock_stream_get_reuseaddr(const struct sock_stream *s)
 {
 	return s ? (int)s->reuseaddr : 0;
+}
+
+static uint8_t sock_stream_linux_st(enum ss_state st)
+{
+	switch (st)
+	{
+	case SS_CONNECTED:
+		return 0x01; /* TCP_ESTABLISHED */
+	case SS_LISTEN:
+		return 0x0A; /* TCP_LISTEN */
+	case SS_BOUND:
+		return 0x07; /* TCP_CLOSE */
+	default:
+		return 0x07;
+	}
+}
+
+int sock_stream_inet_walk(int (*cb)(const struct sock_stream_inet_snap *s,
+				    void *ctx),
+			  void *ctx)
+{
+	int i;
+	struct sock_stream_inet_snap snap;
+
+	if (!cb)
+		return -EINVAL;
+
+	for (i = 0; i < SS_MAX; i++)
+	{
+		struct sock_stream *s = &g_socks[i];
+
+		if (!s->in_use || s->magic != SS_MAGIC)
+			continue;
+		if (s->family != IR0_AF_INET || s->state == SS_IDLE)
+			continue;
+
+		memset(&snap, 0, sizeof(snap));
+#if CONFIG_ENABLE_NETWORKING
+		snap.local_ip = (uint32_t)ip_local_addr;
+#else
+		snap.local_ip = 0;
+#endif
+		snap.local_port = s->wire_local_port ? s->wire_local_port : s->port;
+		if (s->state == SS_CONNECTED)
+		{
+			snap.rem_ip = s->wire_peer_ip;
+			snap.rem_port = s->wire_peer_port;
+		}
+		snap.st = sock_stream_linux_st(s->state);
+		snap.inode = (unsigned long)(uintptr_t)s;
+		if (cb(&snap, ctx) != 0)
+			return -1;
+	}
+	return 0;
+}
+
+int sock_stream_unix_walk(int (*cb)(const struct sock_stream_unix_snap *s,
+				    void *ctx),
+			  void *ctx)
+{
+	int i;
+	struct sock_stream_unix_snap snap;
+
+	if (!cb)
+		return -EINVAL;
+
+	for (i = 0; i < SS_MAX; i++)
+	{
+		struct sock_stream *s = &g_socks[i];
+
+		if (!s->in_use || s->magic != SS_MAGIC)
+			continue;
+		if (s->family != IR0_AF_UNIX || s->state == SS_IDLE)
+			continue;
+
+		memset(&snap, 0, sizeof(snap));
+		snap.inode = (unsigned long)(uintptr_t)s;
+		snap.refcnt = (unsigned)(s->fd_refs > 0 ? s->fd_refs : 1);
+		snap.type = 1; /* SOCK_STREAM */
+		snap.st = sock_stream_linux_st(s->state);
+		snap.path_len = s->path_len;
+		snap.is_abstract = s->is_abstract;
+		if (s->path_len > 0 && s->path_len < sizeof(snap.path))
+			memcpy(snap.path, s->path, s->path_len);
+		if (cb(&snap, ctx) != 0)
+			return -1;
+	}
+	return 0;
 }

--- a/kernel/sock_udp.c
+++ b/kernel/sock_udp.c
@@ -454,3 +454,43 @@ ssize_t sock_udp_recvfrom(struct sock_udp *sock, void *buf, size_t len, int flag
 	return (ssize_t)copy_len;
 #endif
 }
+
+int sock_udp_walk(int (*cb)(const struct sock_udp_snap *s, void *ctx), void *ctx)
+{
+	struct sock_udp *s;
+	struct sock_udp_snap snap;
+	uint64_t flags;
+
+	if (!cb)
+		return -EINVAL;
+
+	flags = sock_irq_save();
+	for (s = sock_bound_list; s; s = s->bound_next)
+	{
+		if (!s->bound)
+			continue;
+		memset(&snap, 0, sizeof(snap));
+#if CONFIG_ENABLE_NETWORKING
+		snap.local_ip = (uint32_t)ip_local_addr;
+#else
+		snap.local_ip = 0;
+#endif
+		snap.local_port = s->local_port;
+		if (s->connected)
+		{
+			snap.rem_ip = s->peer_ip_be;
+			snap.rem_port = s->peer_port;
+			snap.st = 0x01;
+		}
+		else
+			snap.st = 0x07;
+		snap.inode = (unsigned long)(uintptr_t)s;
+		if (cb(&snap, ctx) != 0)
+		{
+			sock_irq_restore(flags);
+			return -1;
+		}
+	}
+	sock_irq_restore(flags);
+	return 0;
+}

--- a/net/dhcp.c
+++ b/net/dhcp.c
@@ -529,12 +529,17 @@ static void dhcp_apply_config(struct dhcp_offer_data *offer)
 
     arp_set_my_ip(ip_local_addr);
 
-    struct net_device *dev = net_get_devices();
-    while (dev)
     {
-        arp_set_interface_ip(dev, ip_local_addr);
-        dev = dev->next;
+        struct net_device *dev = net_get_devices();
+
+        while (dev)
+        {
+            arp_set_interface_ip(dev, ip_local_addr);
+            dev = dev->next;
+        }
     }
+
+    (void)ip_routes_seed_from_globals();
 
     if (offer->dns_server != 0)
     {

--- a/net/ip.c
+++ b/net/ip.c
@@ -693,6 +693,9 @@ int ip_init(void)
 
     LOG_INFO_FMT("IP", "Initializing IPv4 with address " IP4_FMT, IP4_ARGS(ntohl(ip_local_addr)));
 
+    /* Soft FIB mirrors globals so /proc/net/route is not synthesis-only. */
+    (void)ip_routes_seed_from_globals();
+
     /* Register IP protocol handler */
     memset(&ip_proto, 0, sizeof(ip_proto));
     ip_proto.name = "IP";
@@ -709,6 +712,28 @@ int ip_init(void)
 
     LOG_INFO("IP", "IPv4 protocol initialized");
     return 0;
+}
+
+/**
+ * ip_routes_seed_from_globals - Install connected + default into soft FIB.
+ *
+ * Called from ip_init / DHCP / NET_SET_CONFIG so /proc/net/route and LPM
+ * share the same table (ip_route_add updates duplicates in place).
+ */
+int ip_routes_seed_from_globals(void)
+{
+	ip4_addr_t connected;
+	int ret = 0;
+
+	if (ip_local_addr == 0 || ip_netmask == 0)
+		return -EINVAL;
+
+	connected = ip_local_addr & ip_netmask;
+	if (ip_route_add(connected, ip_netmask, 0) != 0)
+		ret = -1;
+	if (ip_gateway != 0 && ip_route_add(0, 0, ip_gateway) != 0)
+		ret = -1;
+	return ret;
 }
 
 /**

--- a/net/ip.h
+++ b/net/ip.h
@@ -68,6 +68,7 @@ int ip_route_del(ip4_addr_t dest_network, ip4_addr_t netmask);
 int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
 			     void *ctx),
 		  void *ctx);
+int ip_routes_seed_from_globals(void);
 
 /* IP Address Utilities */
 static inline ip4_addr_t ip_make_addr(uint8_t a, uint8_t b, uint8_t c, uint8_t d)

--- a/net/tcp.c
+++ b/net/tcp.c
@@ -14,10 +14,15 @@
 #include <ir0/kmem.h>
 #include <ir0/logging.h>
 #include <ir0/clock.h>
+#include <ir0/clock_wait.h>
 #include <ir0/arch_port.h>
 #include <ir0/net.h>
 #include <ir0/errno.h>
 #include <ir0/klog.h>
+#include <ir0/process.h>
+#include <ir0/signals.h>
+#include <ir0/context.h>
+#include <ir0/arch_cpu.h>
 #include <string.h>
 
 #define TCP_WIRE_TIMEOUT_MS 5000U
@@ -1004,11 +1009,17 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		return -EIO;
 	}
 
+	/*
+	 * Yieldable wait so BusyBox nc -w / wget -T (alarm/SIGALRM) can
+	 * interrupt connect. Busy-spin left SIGALRM pending until return.
+	 */
 	deadline = clock_get_uptime_milliseconds() + TCP_WIRE_TIMEOUT_MS;
 	for (;;)
 	{
 		int seen;
 		uint64_t f;
+		uint64_t now;
+		uint64_t slice;
 
 		net_stack_poll();
 		f = tcp_irq_save();
@@ -1016,17 +1027,38 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		tcp_irq_restore(f);
 		if (seen)
 			break;
-		if (clock_get_uptime_milliseconds() >= deadline)
+
+		now = clock_get_uptime_milliseconds();
+		if (now >= deadline)
 		{
 			tcp_pending_clear();
 			return -ETIMEDOUT;
 		}
-		{
-			uint64_t target = clock_get_uptime_milliseconds() + TCP_WIRE_POLL_MS;
 
-			while (clock_get_uptime_milliseconds() < target)
-				;
+		if (current_process &&
+		    signals_pause_should_interrupt(current_process))
+		{
+			handle_signals();
+			if (current_process->saved_context &&
+			    current_process->signal_enter_pending)
+			{
+				current_process->signal_enter_pending = 0;
+				process_restore_user_task_segments(current_process);
+				current_process->irq_frame_saved = 0;
+				current_process->coop_resched_resume = 0;
+				current_process->want_kernel_ret = 0;
+				arch_restore_user_fs_base();
+				tcp_pending_clear();
+				switch_to_user_task(&current_process->task);
+			}
+			tcp_pending_clear();
+			return -EINTR;
 		}
+
+		slice = now + TCP_WIRE_POLL_MS;
+		if (slice > deadline)
+			slice = deadline;
+		(void)ir0_clock_wait_block_until(slice);
 	}
 
 	tcp_build_header(&hdr, lport, peer_port, isn + 1, g_pending.peer_ack,


### PR DESCRIPTION
## Summary
- `tcp_wire_connect` espera con `clock_wait` e interrupción por SIGALRM (`nc -w` ya no cuelga).
- FIB soft sembrada desde `ip_init` / DHCP / `NET_SET_CONFIG` → `route -n` real.
- `/proc/net/{tcp,udp,raw,unix}` con filas desde inventarios sock_* (endian `__be32` Linux-like).

## Test plan
- [x] `nc -w 2 10.0.2.2 9` → `nc: timed out`
- [x] `route -n` soft FIB + seed logs
- [x] `/proc/net/*` + `netstat -aun` → `10.0.2.15:5555`
- [x] `ping -c 2 -W 3 10.0.2.2` → 0% loss
- [x] arch-guard + host 43/43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes syscall-level TCP connect waiting and shared routing/FIB state used by multiple config paths; proc output now reflects kernel socket pointers but does not alter packet handling directly.
> 
> **Overview**
> Improves BusyBox networking smokes by making outbound **TCP connect** yieldable and by aligning **routing** and **netstat** with Linux-shaped `/proc` output.
> 
> **TCP connect** no longer busy-spins while waiting for SYN-ACK: `tcp_wire_connect` polls the stack on timed slices via `ir0_clock_wait_block_until` and honors **SIGALRM** / pause interruption (`nc -w`, wget timeouts) with **`-EINTR`** instead of hanging until the wire timeout.
> 
> The **soft IPv4 FIB** is seeded from runtime globals through new **`ip_routes_seed_from_globals()`** (connected network + default when a gateway is set), invoked from **`ip_init`**, DHCP lease apply, and **`NET_SET_CONFIG`** so **`/proc/net/route`** and **`route -n`** reflect real table entries rather than synthesis-only paths.
> 
> **`/proc/net/{tcp,udp,raw,unix}`** now emit per-socket rows by walking **`sock_*`** inventories (approximate Linux TCP states, **`__be32`** address formatting, inode = socket pointer), replacing header-only stubs for **`netstat`**.
> 
> Docs in **`NETWORKING_MATRIX.md`** record updated smokes (e.g. **`nc -w 2`** PASS) and remaining gaps (non-blocking TCP, fine-grained TCP states in proc).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 304983afe5385421abe6eac057f13d48b1ba7efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->