### PR TITLE
feat(net): EINPROGRESS/POLLOUT wire, wget HTTP y SYN_SENT

### DIFF
--- a/Documentation/releases/NETWORKING_MATRIX.md
+++ b/Documentation/releases/NETWORKING_MATRIX.md
@@ -6,21 +6,22 @@
 | capacidad | implementada | probada | limitación | herramienta |
 |-----------|--------------|---------|------------|-------------|
 | socket(AF_INET, SOCK_DGRAM) | sí | parcial (smokes UDP) | — | `nc` (ISD) |
-| socket(AF_INET, SOCK_STREAM) | sí | parcial | connect interrumpible por SIGALRM (`nc -w`) | `nc` / `wget` |
+| socket(AF_INET, SOCK_STREAM) | sí | sí | wire poll + HTTP | `nc` / `wget` |
 | socket(AF_INET, SOCK_RAW, ICMP) | sí | sí | RX = IP+ICMP (Linux ABI) | `ping` |
-| bind / connect | sí | parcial | — | — |
+| bind / connect | sí | sí | blocking + `SOCK_NONBLOCK` → `EINPROGRESS` | — |
 | listen / accept | sí | parcial | — | — |
-| send/recv / sendto/recvfrom | sí | sí (ICMP/UDP) | — | — |
-| poll on SOCK_STREAM | sí | parcial | — | — |
+| send/recv / sendto/recvfrom | sí | sí | — | — |
+| poll on SOCK_STREAM | sí | sí | wire: POLLIN=RX/FIN, POLLOUT=ESTABLISHED | wget STATUSBAR |
 | poll on SOCK_RAW ICMP | sí | smoke path | readable iff RX queued | — |
+| SO_ERROR / SO_RCVTIMEO / SO_SNDTIMEO | sí | sí (SO_ERROR) | TIMEO en recv stream | — |
 | SIOCGIF* ioctls | sí | sí | read-mostly | `ifconfig -a` |
 | /proc/net/dev | sí | parcial | — | — |
-| /proc/net/route | sí | sí | soft FIB sembrada desde `ip_init`/DHCP/`NET_SET_CONFIG` | `route -n`, `netstat -rn` |
-| /proc/net/{tcp,udp,raw,unix} | sí | sí | filas desde inventarios sock_*; inode = puntero | `netstat` |
+| /proc/net/route | sí | sí | soft FIB sembrada | `route -n` |
+| /proc/net/{tcp,udp,raw,unix} | sí | sí | ESTABLISHED/LISTEN/SYN_SENT | `netstat` |
 | /proc/netinfo | sí | parcial | TSV raw | — |
 | setitimer(ITIMER_REAL) / alarm | sí | sí | SIGALRM mid-syscall + connect wait | BusyBox ping / nc |
 | IPv4 + ICMP echo | sí | sí | QEMU user-net `10.0.2.15` → `10.0.2.2` | `ping` |
-| UDP / TCP | sí | parcial | TCP async/`EINPROGRESS` no | — |
+| UDP / TCP | sí | sí | un solo outbound wire client | — |
 | DNS | parcial | sí (L7) | QEMU user DNS `10.0.2.3` | `nslookup` |
 | virtio-net / RTL8139 | sí | smoke | — | — |
 | AF_NETLINK / ip(8) | **no** | — | no fingir netlink | — |
@@ -33,10 +34,12 @@
 | `ifconfig -a` | PASS — `eth0` `10.0.2.15` |
 | `ping -c 2 -A` / `ping -c 2 -W 3` | PASS |
 | `route -n` / `netstat -rn` | PASS — soft FIB |
-| `netstat` | PASS — filas tcp/udp/raw/unix cuando hay sockets |
+| `netstat` | PASS — filas tcp/udp/raw/unix |
 | `nslookup 10.0.2.2 10.0.2.3` | PASS |
-| `nc -w 2 10.0.2.2 9` | PASS — sale por alarm/EINTR (no hang) |
-| `wget http://10.0.2.2/` | parcial — connect ya no cuelga eterno; HTTP path puede fallar |
+| `nc -w 2 10.0.2.2 9` | PASS — alarm/EINTR |
+| `SOCK_NONBLOCK` connect | PASS — `EINPROGRESS` + `POLLOUT` + `SO_ERROR=0` |
+| `wget http://10.0.2.2/` | PASS — HTML (host :80 vía SLIRP); aviso `close failed: Bad file descriptor` no bloquea body |
+| pid1 `_exit(0)` post-applets | PASS — sin SEGV en argc slot (repair rechaza RIP en stack) |
 
 ## ISD BusyBox (`ir0_full`)
 
@@ -44,6 +47,6 @@ Habilitados: `IFCONFIG`, `PING`, `ROUTE`, `NETSTAT`, `NSLOOKUP`, `NC`, `WGET` (s
 
 ## Pendiente explícito
 
-1. TCP no bloqueante (`EINPROGRESS` + `poll` POLLOUT) y `SO_SNDTIMEO`/`SO_RCVTIMEO` si hace falta para wget HTTP completo.
-2. Estados TCP finos (SYN_SENT, etc.) en `/proc/net/tcp` (hoy: idle/listen/connected aproximados).
-3. SEGV al salir de pid1 tras applets BusyBox (post-smoke; no bloquea connect/route/netstat).
+1. `wget: close failed: Bad file descriptor` al cerrar stdout/`-O -` ( BusyBox + fd; body OK ).
+2. Estados TCP finos restantes (FIN_WAIT*, TIME_WAIT) si hace falta para smokes.
+3. Varias asociaciones TCP wire outbound concurrentes (hoy: un `g_out`).

--- a/arch/x86-64/sources/arch_switch.c
+++ b/arch/x86-64/sources/arch_switch.c
@@ -471,7 +471,8 @@ process_t *prev_proc;
             process_restore_user_task_segments(next_proc);
         }
         else if (process_rip_in_user_range(process_syscall_ip(next_proc)) &&
-                 process_rip_in_user_range(process_syscall_sp(next_proc)))
+                 process_rip_in_user_range(process_syscall_sp(next_proc)) &&
+                 !process_rip_in_user_stack(process_syscall_ip(next_proc)))
         {
             uint64_t rax = next_proc->syscall_resume_rax;
 

--- a/includes/ir0/errno.h
+++ b/includes/ir0/errno.h
@@ -78,8 +78,11 @@
 #define EPROTONOSUPPORT 93
 #define EAFNOSUPPORT 97
 #define ENOBUFS 105
+#define EISCONN 106
 #define ENOTCONN 107
 #define ESHUTDOWN 108
+#define EALREADY 114
+#define EINPROGRESS 115
 
 /* STANDARD FILE DESCRIPTORS                                                */
 

--- a/includes/ir0/process_ctx_invariant.h
+++ b/includes/ir0/process_ctx_invariant.h
@@ -20,6 +20,13 @@
 #define IR0_USER_RIP_LO 0x00400000ULL
 #define IR0_USER_RIP_HI 0x00007FFFFFFFFFFFULL
 
+/* Match includes/ir0/abi/mmap_contract.h — duplicated for host-safe headers. */
+#ifndef IR0_USER_STACK_TOP
+#define IR0_USER_STACK_TOP  0x7FFFF000ULL
+#define IR0_USER_STACK_SIZE 0x80000ULL
+#define IR0_USER_STACK_BASE (IR0_USER_STACK_TOP - IR0_USER_STACK_SIZE)
+#endif
+
 /*
  * process_cs_rip_kernel_ret_bad - True when kernel_ret would jmp to user VA.
  *
@@ -38,4 +45,10 @@ static inline int process_cs_rip_kernel_ret_bad(uint64_t cs, uint64_t rip)
 static inline int process_rip_in_user_range(uint64_t rip)
 {
 	return (rip >= IR0_USER_RIP_LO && rip <= IR0_USER_RIP_HI) ? 1 : 0;
+}
+
+/* Reject stack VAs as executable RIP (Class B repair must not jmp to argc slot). */
+static inline int process_rip_in_user_stack(uint64_t rip)
+{
+	return (rip >= IR0_USER_STACK_BASE && rip < IR0_USER_STACK_TOP) ? 1 : 0;
 }

--- a/includes/ir0/sock_stream.h
+++ b/includes/ir0/sock_stream.h
@@ -35,11 +35,16 @@ int sock_stream_connect_unix_n(struct sock_stream *s, const char *path, size_t p
 struct sock_stream *sock_stream_accept(struct sock_stream *s);
 int sock_stream_bind_inet(struct sock_stream *s, uint16_t port);
 int sock_stream_connect_inet(struct sock_stream *s, uint32_t addr, uint16_t port);
+int sock_stream_connect_inet_flags(struct sock_stream *s, uint32_t addr, uint16_t port,
+				   int nonblock);
 ssize_t sock_stream_send(struct sock_stream *s, const void *buf, size_t len);
 ssize_t sock_stream_recv(struct sock_stream *s, void *buf, size_t len);
 ssize_t sock_stream_recv_flags(struct sock_stream *s, void *buf, size_t len, int flags);
 int sock_stream_set_reuseaddr(struct sock_stream *s, int on);
 int sock_stream_get_reuseaddr(const struct sock_stream *s);
+int sock_stream_take_so_error(struct sock_stream *s);
+int sock_stream_set_timeout_ms(struct sock_stream *s, int is_rcv, uint64_t ms);
+uint64_t sock_stream_get_timeout_ms(const struct sock_stream *s, int is_rcv);
 int sock_stream_is(const void *ptr);
 /* Address in g_socks[] even if already released (magic cleared). */
 int sock_stream_is_slot(const void *ptr);

--- a/includes/ir0/socket.h
+++ b/includes/ir0/socket.h
@@ -33,6 +33,8 @@
 #define SO_ERROR    4
 #define SO_TYPE     3
 #define SO_REUSEADDR 2
+#define SO_RCVTIMEO 20
+#define SO_SNDTIMEO 21
 #define SCM_RIGHTS  1
 
 #define MSG_PEEK     0x2

--- a/kernel/sock_stream.c
+++ b/kernel/sock_stream.c
@@ -31,6 +31,7 @@ enum ss_state
 	SS_IDLE = 0,
 	SS_BOUND,
 	SS_LISTEN,
+	SS_CONNECTING,
 	SS_CONNECTED,
 };
 
@@ -59,6 +60,9 @@ struct sock_stream
 	uint16_t wire_peer_port;
 	uint32_t wire_seq;
 	uint32_t wire_ack;
+	int so_error; /* positive errno for SO_ERROR */
+	uint64_t rcv_timeout_ms; /* 0 = block forever */
+	uint64_t snd_timeout_ms;
 	uint8_t magic;
 	uint8_t rights_n;
 	uint8_t rights[SOCK_STREAM_RIGHTS_MAX][SOCK_STREAM_RIGHTS_ENTRY_SIZE];
@@ -151,13 +155,48 @@ struct sock_stream *sock_stream_get_peer(struct sock_stream *s)
 	return s ? s->peer : NULL;
 }
 
+static int sock_stream_wire_progress(struct sock_stream *s)
+{
+	uint32_t seq;
+	uint32_t ack;
+	int ret;
+
+	if (!s || !s->wire_tcp || s->state != SS_CONNECTING)
+		return 0;
+
+	ret = tcp_wire_connect_poll((ip4_addr_t)s->wire_peer_ip, s->wire_peer_port,
+				    s->wire_local_port, &seq, &ack);
+	if (ret == -EAGAIN)
+		return 0;
+	if (ret < 0)
+	{
+		s->so_error = -ret;
+		s->state = SS_BOUND;
+		poll_wake_check();
+		return ret;
+	}
+	s->wire_seq = seq;
+	s->wire_ack = ack;
+	s->state = SS_CONNECTED;
+	s->so_error = 0;
+	poll_wake_check();
+	return 1;
+}
+
 int sock_stream_poll_readable(const struct sock_stream *s)
 {
+	struct sock_stream *mut = (struct sock_stream *)s;
+
 	if (!s)
 		return 0;
 	/* Pending AF_UNIX/TCP-loopback accept queue (single slot via listener->peer). */
 	if (s->state == SS_LISTEN && s->peer && s->peer->state == SS_CONNECTED)
 		return 1;
+	if (s->state == SS_CONNECTING)
+	{
+		(void)sock_stream_wire_progress(mut);
+		return 0;
+	}
 	if (s->state != SS_CONNECTED)
 		return 0;
 	if (s->rights_n > 0)
@@ -166,6 +205,12 @@ int sock_stream_poll_readable(const struct sock_stream *s)
 		return 1;
 	if (s->shut_rd)
 		return 1;
+#if CONFIG_ENABLE_NETWORKING
+	if (s->wire_tcp)
+		return tcp_wire_poll_readable((ip4_addr_t)s->wire_peer_ip,
+					      s->wire_peer_port,
+					      s->wire_local_port);
+#endif
 	if (!s->peer || s->peer->shut_wr)
 		return 1;
 	return 0;
@@ -173,10 +218,30 @@ int sock_stream_poll_readable(const struct sock_stream *s)
 
 int sock_stream_poll_writable(const struct sock_stream *s)
 {
-	if (!s || s->state != SS_CONNECTED)
+	struct sock_stream *mut = (struct sock_stream *)s;
+
+	if (!s)
 		return 0;
+	if (s->state == SS_CONNECTING)
+	{
+		(void)sock_stream_wire_progress(mut);
+		/* Linux: POLLOUT when connect finished (ok or error). */
+		if (s->state == SS_CONNECTED || s->so_error)
+			return 1;
+		return 0;
+	}
+	if (s->state != SS_CONNECTED)
+		return 0;
+	if (s->so_error)
+		return 1;
 	if (s->shut_wr)
 		return 0;
+#if CONFIG_ENABLE_NETWORKING
+	if (s->wire_tcp)
+		return tcp_wire_poll_writable((ip4_addr_t)s->wire_peer_ip,
+					      s->wire_peer_port,
+					      s->wire_local_port);
+#endif
 	if (!s->peer)
 		return 0;
 	if (s->peer->shut_rd)
@@ -562,6 +627,12 @@ static int sock_stream_is_local_listener(uint16_t port)
 
 int sock_stream_connect_inet(struct sock_stream *s, uint32_t addr, uint16_t port)
 {
+	return sock_stream_connect_inet_flags(s, addr, port, 0);
+}
+
+int sock_stream_connect_inet_flags(struct sock_stream *s, uint32_t addr,
+				   uint16_t port, int nonblock)
+{
 	int i;
 	struct sock_stream *lst = NULL;
 	struct sock_stream *acc;
@@ -570,6 +641,20 @@ int sock_stream_connect_inet(struct sock_stream *s, uint32_t addr, uint16_t port
 		return -EINVAL;
 	if (!sock_stream_inet_addr_allowed(addr))
 		return -ECONNREFUSED;
+	if (s->state == SS_CONNECTING)
+	{
+		int pr = sock_stream_wire_progress(s);
+
+		if (s->state == SS_CONNECTED)
+			return 0;
+		if (s->so_error)
+			return -s->so_error;
+		if (pr == 0)
+			return -EALREADY;
+		return pr < 0 ? pr : 0;
+	}
+	if (s->state == SS_CONNECTED)
+		return -EISCONN;
 
 	if (!sock_stream_is_local_listener(port))
 	{
@@ -578,6 +663,22 @@ int sock_stream_connect_inet(struct sock_stream *s, uint32_t addr, uint16_t port
 		uint32_t seq;
 		uint32_t ack;
 		int ret;
+
+		if (nonblock)
+		{
+			ret = tcp_wire_connect_start((ip4_addr_t)addr, port, &lport);
+			if (ret < 0)
+				return ret;
+			s->wire_tcp = 1;
+			s->wire_local_port = lport;
+			s->wire_peer_ip = addr;
+			s->wire_peer_port = port;
+			s->port = lport;
+			s->peer = NULL;
+			s->so_error = 0;
+			s->state = SS_CONNECTING;
+			return -EINPROGRESS;
+		}
 
 		ret = tcp_wire_connect((ip4_addr_t)addr, port, &lport, &seq, &ack);
 		if (ret < 0)
@@ -591,8 +692,10 @@ int sock_stream_connect_inet(struct sock_stream *s, uint32_t addr, uint16_t port
 		s->port = lport;
 		s->state = SS_CONNECTED;
 		s->peer = NULL;
+		s->so_error = 0;
 		return 0;
 #else
+		(void)nonblock;
 		return -ECONNREFUSED;
 #endif
 	}
@@ -627,10 +730,19 @@ ssize_t sock_stream_send(struct sock_stream *s, const void *buf, size_t len)
 	size_t i;
 	const char *src = buf;
 
-	if (!s || s->state != SS_CONNECTED || !buf)
+	if (!s || (s->state != SS_CONNECTED && s->state != SS_CONNECTING) || !buf)
 		return -EINVAL;
 
 #if CONFIG_ENABLE_NETWORKING
+	if (s->wire_tcp && s->state == SS_CONNECTING)
+	{
+		int pr = sock_stream_wire_progress(s);
+
+		if (s->so_error)
+			return -s->so_error;
+		if (s->state != SS_CONNECTED)
+			return pr < 0 ? pr : -EAGAIN;
+	}
 	if (s->wire_tcp)
 	{
 		uint32_t ack = tcp_wire_peer_ack((ip4_addr_t)s->wire_peer_ip,
@@ -645,6 +757,8 @@ ssize_t sock_stream_send(struct sock_stream *s, const void *buf, size_t len)
 	}
 #endif
 
+	if (s->state != SS_CONNECTED)
+		return -EINVAL;
 	if (s->shut_wr)
 		return -EPIPE;
 	peer = s->peer;
@@ -673,10 +787,18 @@ ssize_t sock_stream_recv_flags(struct sock_stream *s, void *buf, size_t len, int
 	unsigned tail;
 	unsigned count;
 
-	if (!s || s->state != SS_CONNECTED || !buf)
+	if (!s || (s->state != SS_CONNECTED && s->state != SS_CONNECTING) || !buf)
 		return -EINVAL;
 
 #if CONFIG_ENABLE_NETWORKING
+	if (s->wire_tcp && s->state == SS_CONNECTING)
+	{
+		(void)sock_stream_wire_progress(s);
+		if (s->so_error)
+			return -s->so_error;
+		if (s->state != SS_CONNECTED)
+			return -EAGAIN;
+	}
 	if (s->wire_tcp)
 	{
 		int ret;
@@ -740,12 +862,45 @@ int sock_stream_get_reuseaddr(const struct sock_stream *s)
 	return s ? (int)s->reuseaddr : 0;
 }
 
+int sock_stream_take_so_error(struct sock_stream *s)
+{
+	int err;
+
+	if (!s)
+		return 0;
+	if (s->state == SS_CONNECTING)
+		(void)sock_stream_wire_progress(s);
+	err = s->so_error;
+	s->so_error = 0;
+	return err;
+}
+
+int sock_stream_set_timeout_ms(struct sock_stream *s, int is_rcv, uint64_t ms)
+{
+	if (!s)
+		return -EINVAL;
+	if (is_rcv)
+		s->rcv_timeout_ms = ms;
+	else
+		s->snd_timeout_ms = ms;
+	return 0;
+}
+
+uint64_t sock_stream_get_timeout_ms(const struct sock_stream *s, int is_rcv)
+{
+	if (!s)
+		return 0;
+	return is_rcv ? s->rcv_timeout_ms : s->snd_timeout_ms;
+}
+
 static uint8_t sock_stream_linux_st(enum ss_state st)
 {
 	switch (st)
 	{
 	case SS_CONNECTED:
 		return 0x01; /* TCP_ESTABLISHED */
+	case SS_CONNECTING:
+		return 0x02; /* TCP_SYN_SENT */
 	case SS_LISTEN:
 		return 0x0A; /* TCP_LISTEN */
 	case SS_BOUND:
@@ -780,8 +935,8 @@ int sock_stream_inet_walk(int (*cb)(const struct sock_stream_inet_snap *s,
 #else
 		snap.local_ip = 0;
 #endif
-		snap.local_port = s->wire_local_port ? s->wire_local_port : s->port;
-		if (s->state == SS_CONNECTED)
+	snap.local_port = s->wire_local_port ? s->wire_local_port : s->port;
+		if (s->state == SS_CONNECTED || s->state == SS_CONNECTING)
 		{
 			snap.rem_ip = s->wire_peer_ip;
 			snap.rem_port = s->wire_peer_port;

--- a/kernel/syscalls/socket_syscalls.c
+++ b/kernel/syscalls/socket_syscalls.c
@@ -28,8 +28,10 @@
 #include <ir0/sock_stream.h>
 #include <ir0/sock_icmp.h>
 #include <ir0/socket.h>
+#include <ir0/time.h>
 #include <ir0/signals.h>
 #include <ir0/arch_cpu.h>
+#include <ir0/clock.h>
 #include <ir0/pipe.h>
 #include <ir0/vfs.h>
 #include <ir0/memfd.h>
@@ -468,10 +470,16 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 	ss = sock_stream_fd_lookup(fd);
 	if (ss)
 	{
+		uint64_t deadline = 0;
+		uint64_t rto;
+
 		nb = sock_nonblock_fd(fd, flags);
 		kbuf = kmalloc(len);
 		if (!kbuf)
 			return -ENOMEM;
+		rto = sock_stream_get_timeout_ms(ss, 1);
+		if (rto > 0)
+			deadline = clock_get_uptime_milliseconds() + rto;
 		for (;;)
 		{
 			n = sock_stream_recv_flags(ss, kbuf, len, flags);
@@ -481,6 +489,11 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 			{
 				kfree(kbuf);
 				return -EAGAIN;
+			}
+			if (deadline && clock_get_uptime_milliseconds() >= deadline)
+			{
+				kfree(kbuf);
+				return -EAGAIN; /* Linux SO_RCVTIMEO → EAGAIN */
 			}
 			if (signals_pause_should_interrupt(current_process))
 			{
@@ -729,7 +742,9 @@ int64_t sys_connect(int fd, const struct sockaddr *addr, socklen_t addrlen)
 				return -EINVAL;
 			if (copy_from_user(&sin, addr, sizeof(sin)) != 0)
 				return -EFAULT;
-			return sock_stream_connect_inet(ss, sin.sin_addr, ntohs(sin.sin_port));
+			return sock_stream_connect_inet_flags(ss, sin.sin_addr,
+							      ntohs(sin.sin_port),
+							      sock_nonblock_fd(fd, 0));
 		}
 		return -EAFNOSUPPORT;
 	}
@@ -1356,6 +1371,21 @@ int64_t sys_setsockopt(int fd, int level, int optname, const void *optval,
 			return -EFAULT;
 		return sock_stream_set_reuseaddr(ss, val);
 	}
+	if (optname == SO_RCVTIMEO || optname == SO_SNDTIMEO)
+	{
+		struct timeval tv;
+		uint64_t ms;
+
+		if (optlen < sizeof(tv) || !optval)
+			return -EINVAL;
+		if (copy_from_user(&tv, optval, sizeof(tv)) != 0)
+			return -EFAULT;
+		if (tv.tv_sec < 0 || tv.tv_usec < 0 || tv.tv_usec >= 1000000)
+			return -EINVAL;
+		ms = (uint64_t)tv.tv_sec * 1000ULL +
+		     (uint64_t)tv.tv_usec / 1000ULL;
+		return sock_stream_set_timeout_ms(ss, optname == SO_RCVTIMEO, ms);
+	}
 	return -ENOPROTOOPT;
 }
 
@@ -1397,7 +1427,7 @@ int64_t sys_getsockopt(int fd, int level, int optname, void *optval,
 	}
 	if (optname == SO_ERROR)
 	{
-		val = 0;
+		val = sock_stream_take_so_error(ss);
 		if (len < sizeof(val))
 			return -EINVAL;
 		if (copy_to_user(optval, &val, sizeof(val)) != 0)
@@ -1415,6 +1445,22 @@ int64_t sys_getsockopt(int fd, int level, int optname, void *optval,
 		if (copy_to_user(optval, &val, sizeof(val)) != 0)
 			return -EFAULT;
 		len = sizeof(val);
+		if (copy_to_user(optlen, &len, sizeof(len)) != 0)
+			return -EFAULT;
+		return 0;
+	}
+	if (optname == SO_RCVTIMEO || optname == SO_SNDTIMEO)
+	{
+		struct timeval tv;
+		uint64_t ms = sock_stream_get_timeout_ms(ss, optname == SO_RCVTIMEO);
+
+		if (len < sizeof(tv))
+			return -EINVAL;
+		tv.tv_sec = (long)(ms / 1000ULL);
+		tv.tv_usec = (long)((ms % 1000ULL) * 1000ULL);
+		if (copy_to_user(optval, &tv, sizeof(tv)) != 0)
+			return -EFAULT;
+		len = sizeof(tv);
 		if (copy_to_user(optlen, &len, sizeof(len)) != 0)
 			return -EFAULT;
 		return 0;

--- a/net/tcp.c
+++ b/net/tcp.c
@@ -23,6 +23,7 @@
 #include <ir0/signals.h>
 #include <ir0/context.h>
 #include <ir0/arch_cpu.h>
+#include <ir0/poll.h>
 #include <string.h>
 
 #define TCP_WIRE_TIMEOUT_MS 5000U
@@ -61,6 +62,7 @@ struct tcp_pending_conn
 	uint32_t peer_ack;
 	uint16_t peer_window;
 	int synack_seen;
+	uint64_t deadline_ms;
 };
 
 struct tcp_wire_listener
@@ -251,6 +253,8 @@ static void tcp_pending_set(ip4_addr_t peer_ip, uint16_t peer_port,
 	g_pending.peer_port = peer_port;
 	g_pending.local_port = local_port;
 	g_pending.local_seq = local_seq;
+	g_pending.deadline_ms =
+		clock_get_uptime_milliseconds() + TCP_WIRE_TIMEOUT_MS;
 	tcp_irq_restore(f);
 }
 
@@ -980,17 +984,58 @@ uint32_t tcp_wire_peer_ack(ip4_addr_t peer_ip, uint16_t peer_port,
 	return ack;
 }
 
-int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
-		     uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out)
+static int tcp_wire_activate_outbound(ip4_addr_t peer_ip, uint16_t peer_port,
+				      uint16_t lport, uint32_t isn,
+				      uint32_t peer_ack, uint16_t peer_window)
+{
+	struct net_device *dev;
+	struct tcp_header hdr;
+	int ret;
+	uint64_t f;
+
+	dev = net_get_devices();
+	if (!dev)
+		return -ENETUNREACH;
+
+	tcp_build_header(&hdr, lport, peer_port, isn + 1, peer_ack, TCP_FLAG_ACK);
+	ret = tcp_send_raw(dev, peer_ip, &hdr, NULL, 0);
+	if (ret != 0)
+		return -EIO;
+
+	f = tcp_irq_save();
+	memset(&g_out, 0, sizeof(g_out));
+	g_out.active = 1;
+	g_out.peer_ip = peer_ip;
+	g_out.peer_port = peer_port;
+	g_out.local_port = lport;
+	g_out.snd_nxt = isn + 1;
+	g_out.snd_una = isn + 1;
+	g_out.ack_to_peer = peer_ack;
+	g_out.peer_window = peer_window ? peer_window : 8192;
+	g_out.cwnd = 1;
+	g_out.ssthresh = TCP_WIRE_CWND_CAP;
+	g_out.rx_len = 0;
+	g_out.rx_off = 0;
+	g_out.peer_fin = 0;
+	if (peer_port == TCP_WIRE_PEER_CC_PORT)
+	{
+		g_out.peer_cc_mode = 1;
+		g_out.drop_next_tx = 1;
+	}
+	tcp_irq_restore(f);
+	return 0;
+}
+
+int tcp_wire_connect_start(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t *local_port_out)
 {
 	struct net_device *dev;
 	struct tcp_header hdr;
 	uint16_t lport;
 	uint32_t isn;
-	uint64_t deadline;
 	int ret;
 
-	if (!local_port_out || !seq_out || !ack_out || peer_port == 0)
+	if (!local_port_out || peer_port == 0)
 		return -EINVAL;
 
 	dev = net_get_devices();
@@ -1008,6 +1053,125 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		tcp_pending_clear();
 		return -EIO;
 	}
+	*local_port_out = lport;
+	return 0;
+}
+
+int tcp_wire_connect_poll(ip4_addr_t peer_ip, uint16_t peer_port,
+			  uint16_t local_port, uint32_t *seq_out,
+			  uint32_t *ack_out)
+{
+	uint64_t f;
+	int seen;
+	uint32_t isn;
+	uint32_t peer_ack;
+	uint16_t peer_window;
+	uint64_t deadline;
+	int ret;
+
+	if (!seq_out || !ack_out)
+		return -EINVAL;
+
+	net_stack_poll();
+	f = tcp_irq_save();
+	if (!g_pending.active || g_pending.local_port != local_port ||
+	    g_pending.peer_port != peer_port || g_pending.peer_ip != peer_ip)
+	{
+		tcp_irq_restore(f);
+		if (g_out.active && g_out.local_port == local_port &&
+		    g_out.peer_port == peer_port && g_out.peer_ip == peer_ip)
+		{
+			*seq_out = g_out.snd_nxt;
+			*ack_out = g_out.ack_to_peer;
+			return 0;
+		}
+		return -EINVAL;
+	}
+	seen = g_pending.synack_seen;
+	isn = g_pending.local_seq;
+	peer_ack = g_pending.peer_ack;
+	peer_window = g_pending.peer_window;
+	deadline = g_pending.deadline_ms;
+	tcp_irq_restore(f);
+
+	if (!seen)
+	{
+		if (clock_get_uptime_milliseconds() >= deadline)
+		{
+			tcp_pending_clear();
+			return -ETIMEDOUT;
+		}
+		return -EAGAIN;
+	}
+
+	ret = tcp_wire_activate_outbound(peer_ip, peer_port, local_port, isn,
+					 peer_ack, peer_window);
+	tcp_pending_clear();
+	if (ret < 0)
+		return ret;
+	*seq_out = isn + 1;
+	*ack_out = peer_ack;
+	(void)poll_wake_check_nosched();
+	return 0;
+}
+
+int tcp_wire_poll_readable(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t local_port)
+{
+	uint64_t f;
+	int ready = 0;
+	struct tcp_wire_inbound *c;
+
+	f = tcp_irq_save();
+	if (g_out.active && g_out.local_port == local_port &&
+	    g_out.peer_port == peer_port && g_out.peer_ip == peer_ip)
+	{
+		if (g_out.rx_off < g_out.rx_len || g_out.peer_fin)
+			ready = 1;
+		tcp_irq_restore(f);
+		return ready;
+	}
+	c = tcp_inbound_find(peer_ip, peer_port, local_port);
+	if (c && c->taken && (c->rx_off < c->rx_len || c->peer_fin))
+		ready = 1;
+	tcp_irq_restore(f);
+	return ready;
+}
+
+int tcp_wire_poll_writable(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t local_port)
+{
+	uint64_t f;
+	int ready = 0;
+
+	f = tcp_irq_save();
+	if (g_out.active && g_out.local_port == local_port &&
+	    g_out.peer_port == peer_port && g_out.peer_ip == peer_ip)
+	{
+		/* ESTABLISHED: allow send (window check is best-effort). */
+		if (g_out.peer_window > 0)
+			ready = 1;
+		else
+			ready = 1;
+	}
+	tcp_irq_restore(f);
+	return ready;
+}
+
+int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
+		     uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out)
+{
+	uint16_t lport;
+	uint64_t deadline;
+	int ret;
+
+	if (!local_port_out || !seq_out || !ack_out || peer_port == 0)
+		return -EINVAL;
+
+	ret = tcp_wire_connect_start(peer_ip, peer_port, &lport);
+	if (ret < 0)
+		return ret;
+	*local_port_out = lport;
 
 	/*
 	 * Yieldable wait so BusyBox nc -w / wget -T (alarm/SIGALRM) can
@@ -1016,17 +1180,13 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 	deadline = clock_get_uptime_milliseconds() + TCP_WIRE_TIMEOUT_MS;
 	for (;;)
 	{
-		int seen;
-		uint64_t f;
 		uint64_t now;
 		uint64_t slice;
 
-		net_stack_poll();
-		f = tcp_irq_save();
-		seen = g_pending.synack_seen;
-		tcp_irq_restore(f);
-		if (seen)
-			break;
+		ret = tcp_wire_connect_poll(peer_ip, peer_port, lport, seq_out,
+					    ack_out);
+		if (ret != -EAGAIN)
+			return ret;
 
 		now = clock_get_uptime_milliseconds();
 		if (now >= deadline)
@@ -1060,49 +1220,6 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 			slice = deadline;
 		(void)ir0_clock_wait_block_until(slice);
 	}
-
-	tcp_build_header(&hdr, lport, peer_port, isn + 1, g_pending.peer_ack,
-			 TCP_FLAG_ACK);
-	ret = tcp_send_raw(dev, peer_ip, &hdr, NULL, 0);
-	if (ret != 0)
-	{
-		tcp_pending_clear();
-		return -EIO;
-	}
-
-	*local_port_out = lport;
-	*seq_out = isn + 1;
-	*ack_out = g_pending.peer_ack;
-
-	{
-		uint64_t f = tcp_irq_save();
-
-		memset(&g_out, 0, sizeof(g_out));
-		g_out.active = 1;
-		g_out.peer_ip = peer_ip;
-		g_out.peer_port = peer_port;
-		g_out.local_port = lport;
-		g_out.snd_nxt = isn + 1;
-		g_out.snd_una = isn + 1; /* SYN-ACK already covered SYN */
-		g_out.ack_to_peer = g_pending.peer_ack;
-		g_out.peer_window =
-			g_pending.peer_window ? g_pending.peer_window : 8192;
-		g_out.cwnd = 1;
-		g_out.ssthresh = TCP_WIRE_CWND_CAP;
-		g_out.rx_len = 0;
-		g_out.rx_off = 0;
-		g_out.peer_fin = 0;
-		if (peer_port == TCP_WIRE_PEER_CC_PORT)
-		{
-			/* Peer-CC smoke: drop first data TX once; no synthetic DUPACK/SACK. */
-			g_out.peer_cc_mode = 1;
-			g_out.drop_next_tx = 1;
-		}
-		tcp_irq_restore(f);
-	}
-
-	tcp_pending_clear();
-	return 0;
 }
 
 int tcp_wire_send(ip4_addr_t peer_ip, uint16_t peer_port, uint16_t local_port,
@@ -1499,12 +1616,15 @@ void tcp_receive_handler(struct net_device *dev, const void *data, size_t len,
 		g_pending.peer_ack = seq + 1;
 		g_pending.peer_window = window ? window : 8192;
 		tcp_irq_restore(f);
+		(void)poll_wake_check_nosched();
 		return;
 	}
 	if (g_out.active && g_out.local_port == dest_port &&
 	    g_out.peer_port == src_port && g_out.peer_ip == src_ip &&
 	    (flags & TCP_FLAG_ACK))
 	{
+		int wake = 0;
+
 		if (hdr_len > TCP_HDR_LEN)
 			tcp_parse_sack_options((const uint8_t *)data + TCP_HDR_LEN,
 					       hdr_len - TCP_HDR_LEN);
@@ -1535,10 +1655,14 @@ void tcp_receive_handler(struct net_device *dev, const void *data, size_t len,
 				memcpy(g_out.rx + g_out.rx_len, payload, ncopy);
 				g_out.rx_len += (unsigned)ncopy;
 				g_out.ack_to_peer = seq + (uint32_t)ncopy;
+				wake = 1;
 			}
 		}
 		if (flags & TCP_FLAG_FIN)
+		{
 			g_out.peer_fin = 1;
+			wake = 1;
+		}
 		{
 			int print_cwnd = g_out.cwnd_print_pending;
 			int print_sack = g_out.sack_print_pending;
@@ -1552,6 +1676,8 @@ void tcp_receive_handler(struct net_device *dev, const void *data, size_t len,
 				klog_print("F8_TCP_WIRE_CWND_OK\n");
 			if (print_sack)
 				klog_print("F8_TCP_WIRE_SACK_OK\n");
+			if (wake)
+				(void)poll_wake_check_nosched();
 		}
 		return;
 	}

--- a/net/tcp.h
+++ b/net/tcp.h
@@ -37,6 +37,17 @@ struct tcp_header
 int tcp_init(void);
 int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		   uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out);
+/* Nonblocking connect: SYN sent; complete via tcp_wire_connect_poll. */
+int tcp_wire_connect_start(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t *local_port_out);
+/* 0=established, -EAGAIN=still SYN_SENT, other negative = fail. */
+int tcp_wire_connect_poll(ip4_addr_t peer_ip, uint16_t peer_port,
+			  uint16_t local_port, uint32_t *seq_out,
+			  uint32_t *ack_out);
+int tcp_wire_poll_readable(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t local_port);
+int tcp_wire_poll_writable(ip4_addr_t peer_ip, uint16_t peer_port,
+			   uint16_t local_port);
 int tcp_wire_send(ip4_addr_t peer_ip, uint16_t peer_port, uint16_t local_port,
 		  uint32_t *seq_io, uint32_t ack_peer, const void *data, size_t len);
 void tcp_wire_close(ip4_addr_t peer_ip, uint16_t peer_port, uint16_t local_port,


### PR DESCRIPTION
## Summary
- TCP wire: `EINPROGRESS` + `POLLOUT` + `SO_ERROR`; poll POLLIN/POLLOUT correctos para wget.
- `/proc/net/tcp` incluye `SYN_SENT` (`SS_CONNECTING`).
- Class B repair rechaza RIP en stack (evita SEGV argc de pid1 con `return 0`).

## Test plan
- [x] `EINPROGRESS_OK` / `POLLOUT_OK` / `SO_ERROR_OK` / `HTTP_RAW_OK`
- [x] `wget http://10.0.2.2/` descarga HTML
- [x] `_exit(0)` sin SEGV argc; arch-guard + host 43/43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches syscall networking, wire TCP state machine, and x86 context-switch repair paths used on every schedule; changes are well-scoped but core to connect/poll and process resume safety.
> 
> **Overview**
> **TCP and stream sockets** now support Linux-style async connect: `SOCK_NONBLOCK` / `O_NONBLOCK` on `connect` returns **`EINPROGRESS`**, wire progress runs via **`tcp_wire_connect_start`** / **`tcp_wire_connect_poll`**, and **`poll`** exposes **`POLLOUT`** when connect completes (or errors) and **`POLLIN`** when wire RX or FIN is available. **`SO_ERROR`**, **`SO_RCVTIMEO`**, and **`SO_SNDTIMEO`** are wired through **`setsockopt`/`getsockopt`** and stream recv blocking; **`/proc/net/tcp`** reports **`SYN_SENT`** via new **`SS_CONNECTING`** state.
> 
> **Wire TCP** refactors blocking **`tcp_wire_connect`** to poll the same path, adds connect deadlines on pending SYN, and wakes pollers on SYN-ACK and inbound data.
> 
> **Scheduler (x86-64)**: Class B **`KERNEL_CS` + user RIP** repair in **`arch_switch.c`** skips RIPs in the user stack range (**`process_rip_in_user_stack`**), avoiding pid1 SEGV when BusyBox exits with **`_exit(0)`** after applets.
> 
> **Docs**: **`NETWORKING_MATRIX.md`** marks TCP/stream smokes (wget HTTP, nonblock connect) as PASS and updates open limitations (single outbound **`g_out`**, wget close BDF warning).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab3b5d4c943c0e583c7f33477994292e451973f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->