### PR TITLE
fix(net): wget -O - sin EBADF y CLOSE_WAIT

### DIFF
--- a/Documentation/releases/NETWORKING_MATRIX.md
+++ b/Documentation/releases/NETWORKING_MATRIX.md
@@ -14,10 +14,11 @@
 | poll on SOCK_STREAM | sí | sí | wire: POLLIN=RX/FIN, POLLOUT=ESTABLISHED | wget STATUSBAR |
 | poll on SOCK_RAW ICMP | sí | smoke path | readable iff RX queued | — |
 | SO_ERROR / SO_RCVTIMEO / SO_SNDTIMEO | sí | sí (SO_ERROR) | TIMEO en recv stream | — |
+| close(1)/close(2) consola | sí | sí | Linux-like; wget `-O -` | BusyBox wget |
 | SIOCGIF* ioctls | sí | sí | read-mostly | `ifconfig -a` |
 | /proc/net/dev | sí | parcial | — | — |
 | /proc/net/route | sí | sí | soft FIB sembrada | `route -n` |
-| /proc/net/{tcp,udp,raw,unix} | sí | sí | ESTABLISHED/LISTEN/SYN_SENT | `netstat` |
+| /proc/net/{tcp,udp,raw,unix} | sí | sí | ESTABLISHED/LISTEN/SYN_SENT/CLOSE_WAIT | `netstat` |
 | /proc/netinfo | sí | parcial | TSV raw | — |
 | setitimer(ITIMER_REAL) / alarm | sí | sí | SIGALRM mid-syscall + connect wait | BusyBox ping / nc |
 | IPv4 + ICMP echo | sí | sí | QEMU user-net `10.0.2.15` → `10.0.2.2` | `ping` |
@@ -38,8 +39,8 @@
 | `nslookup 10.0.2.2 10.0.2.3` | PASS |
 | `nc -w 2 10.0.2.2 9` | PASS — alarm/EINTR |
 | `SOCK_NONBLOCK` connect | PASS — `EINPROGRESS` + `POLLOUT` + `SO_ERROR=0` |
-| `wget http://10.0.2.2/` | PASS — HTML (host :80 vía SLIRP); aviso `close failed: Bad file descriptor` no bloquea body |
-| pid1 `_exit(0)` post-applets | PASS — sin SEGV en argc slot (repair rechaza RIP en stack) |
+| `wget -q -O - http://10.0.2.2/` | PASS — HTML; sin `close failed: Bad file descriptor` |
+| pid1 `_exit(0)` post-applets | PASS — sin SEGV argc |
 
 ## ISD BusyBox (`ir0_full`)
 
@@ -47,6 +48,5 @@ Habilitados: `IFCONFIG`, `PING`, `ROUTE`, `NETSTAT`, `NSLOOKUP`, `NC`, `WGET` (s
 
 ## Pendiente explícito
 
-1. `wget: close failed: Bad file descriptor` al cerrar stdout/`-O -` ( BusyBox + fd; body OK ).
-2. Estados TCP finos restantes (FIN_WAIT*, TIME_WAIT) si hace falta para smokes.
-3. Varias asociaciones TCP wire outbound concurrentes (hoy: un `g_out`).
+1. FIN_WAIT1/2 / TIME_WAIT completos (hoy: CLOSE_WAIT si peer FIN).
+2. Varias asociaciones TCP wire outbound concurrentes (hoy: un `g_out`).

--- a/kernel/sock_stream.c
+++ b/kernel/sock_stream.c
@@ -942,6 +942,12 @@ int sock_stream_inet_walk(int (*cb)(const struct sock_stream_inet_snap *s,
 			snap.rem_port = s->wire_peer_port;
 		}
 		snap.st = sock_stream_linux_st(s->state);
+#if CONFIG_ENABLE_NETWORKING
+		if (s->wire_tcp && s->state == SS_CONNECTED &&
+		    tcp_wire_peer_fin((ip4_addr_t)s->wire_peer_ip,
+				     s->wire_peer_port, s->wire_local_port))
+			snap.st = 0x08; /* TCP_CLOSE_WAIT */
+#endif
 		snap.inode = (unsigned long)(uintptr_t)s;
 		if (cb(&snap, ctx) != 0)
 			return -1;

--- a/kernel/syscalls/io_syscalls.c
+++ b/kernel/syscalls/io_syscalls.c
@@ -1186,8 +1186,16 @@ int64_t sys_close(int fd)
     int was_pipe = fd_table[fd].is_pipe ? 1 : 0;
     int was_devfs = fd_table[fd].is_devfs ? 1 : 0;
 
+    /*
+     * Linux allows close(0/1/2) on the console slots. BusyBox wget -O -
+     * ends with xclose(1); refusing with EBADF prints "close failed".
+     */
     if (fd <= 2 && !was_pipe && !was_devfs && !fd_table[fd].vfs_file)
-      return -EBADF;
+    {
+      fd_table[fd].in_use = false;
+      fd_table[fd].flags = 0;
+      return 0;
+    }
 
     if (was_devfs)
     {

--- a/net/tcp.c
+++ b/net/tcp.c
@@ -1158,6 +1158,24 @@ int tcp_wire_poll_writable(ip4_addr_t peer_ip, uint16_t peer_port,
 	return ready;
 }
 
+int tcp_wire_peer_fin(ip4_addr_t peer_ip, uint16_t peer_port,
+		      uint16_t local_port)
+{
+	uint64_t f;
+	int fin = 0;
+	struct tcp_wire_inbound *c;
+
+	f = tcp_irq_save();
+	if (g_out.active && g_out.local_port == local_port &&
+	    g_out.peer_port == peer_port && g_out.peer_ip == peer_ip)
+		fin = g_out.peer_fin;
+	c = tcp_inbound_find(peer_ip, peer_port, local_port);
+	if (c && c->taken && c->peer_fin)
+		fin = 1;
+	tcp_irq_restore(f);
+	return fin;
+}
+
 int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		     uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out)
 {

--- a/net/tcp.h
+++ b/net/tcp.h
@@ -48,6 +48,9 @@ int tcp_wire_poll_readable(ip4_addr_t peer_ip, uint16_t peer_port,
 			   uint16_t local_port);
 int tcp_wire_poll_writable(ip4_addr_t peer_ip, uint16_t peer_port,
 			   uint16_t local_port);
+/** 1 if outbound/inbound association has seen peer FIN. */
+int tcp_wire_peer_fin(ip4_addr_t peer_ip, uint16_t peer_port,
+		      uint16_t local_port);
 int tcp_wire_send(ip4_addr_t peer_ip, uint16_t peer_port, uint16_t local_port,
 		  uint32_t *seq_io, uint32_t ack_peer, const void *data, size_t len);
 void tcp_wire_close(ip4_addr_t peer_ip, uint16_t peer_port, uint16_t local_port,


### PR DESCRIPTION
## Summary
- `close(1)`/`close(2)` en consola ya no devuelve `EBADF` (BusyBox `wget -O -`).
- `/proc/net/tcp` reporta `CLOSE_WAIT` cuando el peer envió FIN.

## Test plan
- [x] `wget -q -O - http://10.0.2.2/` → HTML, sin `close failed`
- [x] arch-guard + host 43/43

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes syscall close semantics for stdio fds (could affect programs that relied on EBADF) and TCP proc reporting; scope is narrow and targeted at BusyBox networking smokes.
> 
> **Overview**
> Aligns **console `close(0/1/2)`** with Linux: unredirected stdin/stdout/stderr slots can be closed successfully instead of returning `EBADF`, so BusyBox **`wget -O -`** no longer prints `close failed: Bad file descriptor` after `xclose(1)`.
> 
> Adds **`tcp_wire_peer_fin`** and uses it when exporting inet sockets so **`/proc/net/tcp`** shows **`CLOSE_WAIT`** (`0x08`) when the wire stack has seen a peer FIN on a still-connected stream socket, improving **`netstat`** fidelity.
> 
> **`NETWORKING_MATRIX.md`** documents the close behavior, the updated wget smoke, and notes that full FIN_WAIT/TIME_WAIT states remain future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c7ddf5f9d8930c4d91b68ecba79ac4fadc08932. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->