### PR TITLE
release(0.0.1): v0.0.1-rc4 último pre-release

### DIFF
--- a/Documentation/BACKLOG_REMAINING.md
+++ b/Documentation/BACKLOG_REMAINING.md
@@ -198,7 +198,9 @@ Slice: connect+send/recv to QEMU gateway **10.0.2.2:8888** (MVP, not full stack)
 
 virtiofs/FUSE remains **Future** (no guest FUSE). Host-share remains virtio-**9p**.
 
-Tag `v0.0.1-rc2` = automated critical gates only; **ship** still needs Maintainer manual VM above.
+Tag `v0.0.1-rc4` = **last pre-release** (feature freeze for 0.0.1 surface); post-rc4 = bugfix /
+stabilization only. **Ship** `v0.0.1` still needs Maintainer manual VM above. See
+[`releases/IR0_0.0.1_RC4.md`](releases/IR0_0.0.1_RC4.md).
 
 ## ARM64 — honest status (2026-07-12)
 

--- a/Documentation/CHANGELOG.md
+++ b/Documentation/CHANGELOG.md
@@ -1,10 +1,24 @@
 # IR0 Kernel Changelog
 
-> **Last verified:** 2026-07-29
+> **Last verified:** 2026-07-30
 > **Source of truth:** git history, `make ktm-check`, roadmap smokes in `Makefile`, [`HARDENING.md`](HARDENING.md), [`KTM.md`](KTM.md)
 
 This file tracks user-visible and developer-facing changes per iteration.
 For tier backlog see [`ROADMAP.md`](ROADMAP.md). For **what is stable in QEMU** see [`STABLE.md`](STABLE.md).
+
+## [0.0.1-rc4] — 2026-07-30 (last pre-release)
+
+Tag: **`v0.0.1-rc4`**. Version string: `0.0.1-rc4`.  
+Policy: after this tag, **bugfixing and stabilization only** until final `v0.0.1`.  
+Notes: [`releases/IR0_0.0.1_RC4.md`](releases/IR0_0.0.1_RC4.md), [`releases/NETWORKING_MATRIX.md`](releases/NETWORKING_MATRIX.md).
+
+### Networking product path + stress (ISD BusyBox `ir0_full`)
+
+- `ifconfig` / `route` mutate: `SIOCSIF*`, `SIOCADDRT` / `SIOCDELRT`; Linux `IFF_*`; RTL8139 link polarity.
+- AF_UNIX `SOCK_DGRAM` for musl `if_nametoindex`; ICMP `IP_TTL` / `SO_BINDTODEVICE` / `IP_MULTICAST_IF`.
+- TCP connect interruptible; SIGALRM → `-ETIMEDOUT` (safe `nc -w`); connect lock released on process exit.
+- RTL8139 RX uses **CBR**; overflow drain (fixes RX wedge under load).
+- Stress: `setup/pid1/net_command_stress.c` → `NET_STRESS_PASS` / `NC_ONLY_PASS`.
 
 ## [Unreleased]
 

--- a/Documentation/ROADMAP.md
+++ b/Documentation/ROADMAP.md
@@ -262,7 +262,8 @@ SMP, CFS backend, kernel modules (MOD-*) — see P2 below.
 | 17b | **Full ash + required applets in rootfs** | **BUSY-1 DONE** — `IR0-userspace/packages/busybox/required_applets.txt` + inject on runit disk |
 | 17c | **Applet smoke** | **BUSY-2 DONE** — `make smoke-busybox-manifest` → `BUSYBOX_MANIFEST_OK` |
 
-Tag `v0.0.1-rc2` closed automated product gates except maintainer **manual VM** for final ship.
+Tag `v0.0.1-rc4` is the **last pre-release** before final; remaining work to `v0.0.1` is bugfix /
+stabilization + maintainer **manual VM**. See [`releases/IR0_0.0.1_RC4.md`](releases/IR0_0.0.1_RC4.md).
 
 ### P3 — network + desktop (after P1-storage stable)
 

--- a/Documentation/STABLE.md
+++ b/Documentation/STABLE.md
@@ -1,15 +1,15 @@
 # IR0 — Stable baseline (release 0.0.1)
 
-> **Last verified:** 2026-07-25  
+> **Last verified:** 2026-07-30  
 > **Source of truth:** `make release-0.0.1` / CTR gates, `Makefile` smoke targets,  
 > hostshare-exec + F8 **honest MVP** (`smoke-f8-net`) + FAT secondary ship note,  
 > runit PID1 + hybrid 9p payload (`runit_hostshare_payload_run`) for desktop X smoke,  
 > merge `56a3f7b` (dev→master: kexec/S3, P1-storage, P1-T1), Future F2–F6,  
 > `Documentation/releases/IR0_0.0.1_SCOPE.md`, [`BACKLOG_REMAINING.md`](BACKLOG_REMAINING.md),  
+> [`releases/IR0_0.0.1_RC4.md`](releases/IR0_0.0.1_RC4.md), [`releases/NETWORKING_MATRIX.md`](releases/NETWORKING_MATRIX.md),  
 > critical hybrid KTM battery ([`KTM.md`](KTM.md) § critical product battery),  
-> **SEP-2** userspace split: product rootfs built by the **`IR0-userspace`** sibling
-> (`IR0_USERSPACE_ROOT`, `make headers_install`) — see [`USERSPACE.md`](USERSPACE.md) and
-> [`TREE_CONTRACT`](../../IR0-desktop/Documentation/TREE_CONTRACT.md).
+> **SEP-2** userspace split: product rootfs built by the **`IR0-userspace`** / **ISD** sibling
+> (`IR0_USERSPACE_ROOT`, `make headers_install`) — see [`USERSPACE.md`](USERSPACE.md).
 > In-kernel dbgshell / `debug_bins/` **removed** (2026-07-25).
 
 This document is the **single checklist** for what is **stable enough to run and test in QEMU** (serial and GTK UI), what was formerly **in development** and is now closed for **0.0.1**, and what remains **future work** (see [`ROADMAP.md`](ROADMAP.md) P1+).
@@ -21,14 +21,16 @@ full-copied user pages. Real share-on-fork + write-fault break landed in `62cc51
 `make smoke-mm-cow-lazy`. KTM is the canonical in-kernel test plane (`make ktm-run`,
 `make ktm-userdev-run`); see [`ai_driven_dev/ktm.md`](ai_driven_dev/ktm.md).
 
-### Tag prep vs release ship (2026-07-12)
+### Tag prep vs release ship (2026-07-30)
 
 | Artifact | Meaning |
 |----------|---------|
-| **`v0.0.1-rc2`** | Pre-release **tag prep**: critical automated gates green (TCC, Doom+IWAD, posix, hostshare, arch-guard). **Not** a shipped release. |
-| **Release 0.0.1 ship** | Maintainer only: **manual QEMU/VM** walkthrough “listo”. Automated BusyBox product path (**BUSY-1** manifest + **BUSY-2** `ktm-userdev-busybox-manifest-run` / alias `smoke-busybox-manifest`) is green. |
+| **`v0.0.1-rc4`** | **Last pre-release** before final. Version string `0.0.1-rc4`. Networking stress green (`NET_STRESS_PASS`). Details: [`releases/IR0_0.0.1_RC4.md`](releases/IR0_0.0.1_RC4.md). |
+| **Post-rc4 work** | **Bugfixing + stabilization only** — no new 0.0.1 product surface. |
+| **`v0.0.1` (final ship)** | Maintainer: **manual QEMU/VM** “listo” + SCOPE blockers cleared. |
+| Earlier | `v0.0.1-rc2` / `rc1` / `pre.1` — historical tag prep only. |
 
-Do **not** treat `v0.0.1-rc2` (or earlier `rc1`/`pre.1`) as “0.0.1 done”. Final git tag `v0.0.1` waits on ship criteria above.
+Do **not** treat any `rc*` tag as “0.0.1 done”. Final git tag `v0.0.1` waits on ship criteria above.
 
 ---
 

--- a/Documentation/esp/CHANGELOG.md
+++ b/Documentation/esp/CHANGELOG.md
@@ -1,9 +1,14 @@
 # IR0 Kernel — Changelog (español)
 
-> **Última verificación:** 2026-07-25  
+> **Última verificación:** 2026-07-30  
 > **Fuente de verdad:** historial git, smokes del `Makefile`, [`../STABLE.md`](../STABLE.md), [`../KTM.md`](../KTM.md)
 
 Versión en inglés (canónica): [`../CHANGELOG.md`](../CHANGELOG.md).
+
+## [0.0.1-rc4] — 2026-07-30 (último pre-release)
+
+Tag **`v0.0.1-rc4`**. Tras este tag: **solo bugfixing y estabilización** hasta `v0.0.1` final.  
+Detalle: [`../releases/IR0_0.0.1_RC4.md`](../releases/IR0_0.0.1_RC4.md).
 
 ## [Sin publicar]
 

--- a/Documentation/esp/STABLE.md
+++ b/Documentation/esp/STABLE.md
@@ -1,9 +1,10 @@
 # IR0 — Baseline estable (release 0.0.1)
 
-> **Última verificación:** 2026-07-18  
+> **Última verificación:** 2026-07-30  
 > **Fuente de verdad:** smokes/`Makefile`, merge `56a3f7b` (kexec/S3, P1-storage, P1-T1),  
 > F8 MVP honesto (`smoke-f8-net`), Future F2–F6, híbrido runit+9p (`runit_hostshare_payload_run`),  
-> [`../HARDENING.md`](../HARDENING.md), [`../ROADMAP.md`](../ROADMAP.md), gates CTR.
+> [`../releases/IR0_0.0.1_RC4.md`](../releases/IR0_0.0.1_RC4.md), [`../HARDENING.md`](../HARDENING.md),  
+> [`../ROADMAP.md`](../ROADMAP.md), gates CTR.
 
 Checklist único de lo **estable para probar en QEMU** (serial y GTK), lo que **estaba en desarrollo** y quedó **cerrado en 0.0.1**, y lo que sigue siendo **trabajo futuro** ([`ROADMAP.md`](../ROADMAP.md) P1+).
 
@@ -14,10 +15,11 @@ kernel aún hacía full-copy. El share-on-fork real + break en write fault está
 (`make smoke-mm-cow-lazy`). KTM es el plano de test canónico (`make ktm-run`,
 `make ktm-userdev-run`); ver [`../ai_driven_dev/ktm.md`](../ai_driven_dev/ktm.md).
 
-### Tag prep vs ship (2026-07-12)
+### Tag prep vs ship (2026-07-30)
 
-- **`v0.0.1-rc2`**: tag prep (gates críticos automáticos). **No** es el release.
-- **Ship 0.0.1**: VM manual del mantenedor. BusyBox producto (**BUSY-1/2**) cerrado con `smoke-busybox-manifest`.
+- **`v0.0.1-rc4`**: **último pre-release** antes del final (`0.0.1-rc4`). Tras el tag: solo bugfixing/estabilización.
+- **Ship `v0.0.1`**: VM manual del mantenedor + blockers de SCOPE.
+- Detalle: [`../releases/IR0_0.0.1_RC4.md`](../releases/IR0_0.0.1_RC4.md).
 
 ---
 

--- a/Documentation/releases/IR0_0.0.1_RC4.md
+++ b/Documentation/releases/IR0_0.0.1_RC4.md
@@ -1,0 +1,66 @@
+# IR0 v0.0.1-rc4 — last pre-release before 0.0.1 final
+
+> **Última verificación:** 2026-07-30  
+> **Fuente de verdad:** tag git `v0.0.1-rc4`, `includes/ir0/version.h` (`0.0.1-rc4`),  
+> [`NETWORKING_MATRIX.md`](NETWORKING_MATRIX.md), [`../STABLE.md`](../STABLE.md)
+
+## Meaning
+
+| Artifact | Meaning |
+|----------|---------|
+| **`v0.0.1-rc4`** | **Last** release-candidate / pre-release tag before ship. Feature freeze for 0.0.1 surface. |
+| **Post-rc4 → `v0.0.1`** | **Bugfixing and stabilization only** — no new product surface for the 0.0.1 ship. |
+| **`v0.0.1` (final)** | Maintainer ship after manual VM + remaining blockers in [`IR0_0.0.1_SCOPE.md`](IR0_0.0.1_SCOPE.md). |
+
+Earlier tags: `v0.0.1-pre.1`, `v0.0.1-rc1`, `v0.0.1-rc2`. There is no git tag `rc3`; the tree carried string `0.0.1-pre-rc3` until this bump.
+
+## What landed in the rc4 window (networking / stress)
+
+Honest product path for ISD BusyBox `ir0_full` networking applets under QEMU user-net + RTL8139:
+
+- `ifconfig` / `route` mutate ioctls (`SIOCSIF*`, `SIOCADDRT` / `SIOCDELRT`)
+- Linux-correct `IFF_*` + RTL8139 link polarity (eth0 not stuck “down” / LOOPBACK)
+- AF_UNIX `SOCK_DGRAM` for musl `if_nametoindex` (`ping -I eth0`)
+- ICMP: `IP_TTL`, `SO_BINDTODEVICE`, `IP_MULTICAST_IF`
+- TCP connect: yieldable wait; SIGALRM during connect → `-ETIMEDOUT` (BusyBox `nc -w` safe)
+- RTL8139 RX: CBR register (not `rx_buffer+0x10`); overflow drain so RX does not wedge under load
+- Single outbound wire TCP association (`g_out`) — documented limit; no parallel `wget`∥`wget`
+
+Stress evidence (pid1 harness `setup/pid1/net_command_stress.c`):
+
+| Gate | Result |
+|------|--------|
+| `NC_ONLY_PASS` (5× `nc -w`) | PASS |
+| `NET_STRESS_PASS` (8 rounds applets) | PASS |
+| `kernel-x64.bin` + `arch-guard` + `build-matrix-min` + `tests/host` | PASS |
+
+## Post-rc4 policy (until `v0.0.1`)
+
+**In scope**
+
+- Regression fixes (SEGV, RX wedge, errno, smoke flakes)
+- Stabilization of existing applets / ABI / smokes
+- Docs honesty (matrix, STABLE, SCOPE blockers)
+
+**Out of scope for 0.0.1 final**
+
+- New networking surface (multi outbound TCP clients, netlink/`ip`(8), IPv6, DHCP client)
+- Tier-2/3 expansion (WM, new graphics stack) as ship blockers
+- “Nice to have” applets not already in the product path
+
+## How to reproduce networking stress
+
+```bash
+make -s kernel-x64.bin kernel-x64-userspace.iso
+gcc -static -O2 -o /tmp/net_command_stress setup/pid1/net_command_stress.c
+cp -f disk.img /tmp/ir0-stress-disk.img
+python3 scripts/inject_init_minix.py /tmp/ir0-stress-disk.img /tmp/net_command_stress sbin/init
+./scripts/smoke_qemu_run.sh --log /tmp/net_stress.log --timeout 300 --stale-sec 60 \
+  --done 'NET_STRESS_PASS|NET_STRESS_FAIL' --fail-regex 'KERNEL PANIC|CONSOLE_SESSION_SEGV' -- \
+  qemu-system-x86_64 -cdrom kernel-x64-userspace.iso \
+  -drive file=/tmp/ir0-stress-disk.img,format=raw,if=ide,index=0 \
+  -netdev user,id=net0 -device rtl8139,netdev=net0 \
+  -serial stdio -display none -m 256M -no-reboot
+```
+
+Terminal success tag: `NET_STRESS_PASS`.

--- a/Documentation/releases/IR0_0.0.1_SCOPE.md
+++ b/Documentation/releases/IR0_0.0.1_SCOPE.md
@@ -1,8 +1,12 @@
 # IR0 0.0.1 — Release scope (honest inventory)
 
-> **Last verified:** 2026-06-26  
+> **Last verified:** 2026-07-30  
 > **Source of truth:** `make smoke-release-0.0.1`, `Documentation/releases/IR0_0.0.1_SCOPE.md`,  
-> `scripts/linux_abi/contracts.json`, `kernel/test/`, `tests/host/`, Makefile smoke targets
+> `scripts/linux_abi/contracts.json`, `kernel/test/`, `tests/host/`, Makefile smoke targets,  
+> last pre-release tag [`IR0_0.0.1_RC4.md`](IR0_0.0.1_RC4.md) (`v0.0.1-rc4`)
+
+**Post-rc4 policy:** until final `v0.0.1`, only bugfixing and stabilization of the existing
+0.0.1 surface — no new product features for this ship.
 
 ## Release gate (D1.20)
 

--- a/Documentation/releases/NETWORKING_MATRIX.md
+++ b/Documentation/releases/NETWORKING_MATRIX.md
@@ -1,11 +1,12 @@
 # Networking capability matrix (lista §9)
 
 > **Última verificación:** 2026-07-30  
-> **Fuente de verdad:** código kernel + ISD BusyBox; smokes QEMU user-net (`rtl8139`).
+> **Fuente de verdad:** código kernel + ISD BusyBox (`ir0_full`); smoke `NET_FLAGS_PASS` (QEMU user-net `rtl8139`).
 
 | capacidad | implementada | probada | limitación | herramienta |
 |-----------|--------------|---------|------------|-------------|
 | socket(AF_INET, SOCK_DGRAM) | sí | parcial (smokes UDP) | — | `nc` (ISD) |
+| socket(AF_UNIX, SOCK_DGRAM) | sí | sí | ioctl control (musl `if_nametoindex`) | `ping -I eth0` |
 | socket(AF_INET, SOCK_STREAM) | sí | sí | wire poll + HTTP | `nc` / `wget` |
 | socket(AF_INET, SOCK_RAW, ICMP) | sí | sí | RX = IP+ICMP (Linux ABI) | `ping` |
 | bind / connect | sí | sí | blocking + `SOCK_NONBLOCK` → `EINPROGRESS` | — |
@@ -14,8 +15,11 @@
 | poll on SOCK_STREAM | sí | sí | wire: POLLIN=RX/FIN, POLLOUT=ESTABLISHED | wget STATUSBAR |
 | poll on SOCK_RAW ICMP | sí | smoke path | readable iff RX queued | — |
 | SO_ERROR / SO_RCVTIMEO / SO_SNDTIMEO | sí | sí (SO_ERROR) | TIMEO en recv stream | — |
+| SO_BINDTODEVICE / IP_TTL / IP_MULTICAST_IF | sí | sí | single-NIC; MULTICAST_IF→bind src | `ping -I` / `-t` |
 | close(1)/close(2) consola | sí | sí | Linux-like; wget `-O -` | BusyBox wget |
-| SIOCGIF* ioctls | sí | sí | read-mostly | `ifconfig -a` |
+| SIOCGIF* / SIOCSIF* ioctls | sí | sí | addr/flags/mask/bcast/mtu/hw/metric/txqlen | `ifconfig` |
+| SIOCADDRT / SIOCDELRT | sí | sí | soft FIB | `route add` / `del` |
+| SIOCGIFINDEX / SIOCGIFNAME | sí | sí | — | musl `if_nametoindex` |
 | /proc/net/dev | sí | parcial | — | — |
 | /proc/net/route | sí | sí | soft FIB sembrada | `route -n` |
 | /proc/net/{tcp,udp,raw,unix} | sí | sí | ESTABLISHED/LISTEN/SYN_SENT/CLOSE_WAIT | `netstat` |
@@ -32,21 +36,42 @@
 
 | Smoke | Resultado |
 |-------|-----------|
-| `ifconfig -a` | PASS — `eth0` `10.0.2.15` |
-| `ping -c 2 -A` / `ping -c 2 -W 3` | PASS |
-| `route -n` / `netstat -rn` | PASS — soft FIB |
-| `netstat` | PASS — filas tcp/udp/raw/unix |
-| `nslookup 10.0.2.2 10.0.2.3` | PASS |
-| `nc -w 2 10.0.2.2 9` | PASS — alarm/EINTR |
-| `SOCK_NONBLOCK` connect | PASS — `EINPROGRESS` + `POLLOUT` + `SO_ERROR=0` |
-| `wget -q -O - http://10.0.2.2/` | PASS — HTML; sin `close failed: Bad file descriptor` |
-| pid1 `_exit(0)` post-applets | PASS — sin SEGV argc |
+| `ifconfig eth0 … up` / `mtu` / `txqueuelen` / broadcast | PASS |
+| `route add default gw` / `route -n` / `route del default` | PASS |
+| `ping -c 1 -I eth0` / `ping -I 10.0.2.15` | PASS — AF_UNIX dgram + MULTICAST_IF |
+| `ping -t 32` / `-q -s 32` | PASS — `IP_TTL` |
+| `netstat` / `netstat -rn` | PASS |
+| `wget -q -O - http://10.0.2.2/` | PASS |
+| `nc -w 2` / `SOCK_NONBLOCK` connect | PASS — SIGALRM → `-ETIMEDOUT` (no die-from-handler SEGV) |
+| Tag `NET_FLAGS_PASS` | PASS |
+| Tag `NET_STRESS_PASS` (8 rounds, `setup/pid1/net_command_stress.c`) | PASS |
+| Tag `NC_ONLY_PASS` (5× `nc -w`) | PASS |
 
-## ISD BusyBox (`ir0_full`)
+## Stress / stability notes (rc4)
 
-Habilitados: `IFCONFIG`, `PING`, `ROUTE`, `NETSTAT`, `NSLOOKUP`, `NC`, `WGET` (sin `UDHCPC`/`HTTPD`/`TELNETD`).
+| Issue found under stress | Fix |
+|--------------------------|-----|
+| Repeat `nc -w` → userspace SEGV @ `rsp-8` | Defer catchable signals in connect; map lone SIGALRM to `-ETIMEDOUT` |
+| After parallel load, ping TX ok / RX stuck | RTL8139 read **CBR** (I/O `0x3A`), not `rx_buffer+0x10`; drain on RxOverflow |
+| Connect lock stuck after SEGV mid-connect | `tcp_wire_on_process_exit` releases owner |
+| Parallel `wget`∥`wget` SEGV | Single `g_out` — stress uses concurrent **ping** only |
+
+## ISD BusyBox (`ir0_full`) — flags ON vs kernel
+
+| applet | flags ON (config) | kernel status |
+|--------|-------------------|---------------|
+| `ifconfig` | mutate + HW + broadcast+ | SIOCS* OK |
+| `ping` | fancy: `-c/-s/-t/-w/-W/-I/-q/-v/-A/-p/-i/-n` | OK (IPv4) |
+| `route` | add/del / `-n` | SIOCADDRT/DELRT OK |
+| `netstat` | `-rn` + tabla | `/proc/net/*` OK |
+| `nslookup` | mini (no `NSLOOKUP_BIG`) | DNS L7 OK |
+| `nc` | `-w/-l/-p` (no `-u`; `NC_110_COMPAT=n`) | OK |
+| `wget` | `-q/-O/-c` (no `-T`/HTTPS; features off) | OK |
+
+Flags **OFF** en `ir0_full` (no producto): `FEATURE_WGET_TIMEOUT` (`-T`), `NC_110_COMPAT` (`-u`), IPv6, `NSLOOKUP_BIG`, `UDHCPC`.
 
 ## Pendiente explícito
 
 1. FIN_WAIT1/2 / TIME_WAIT completos (hoy: CLOSE_WAIT si peer FIN).
 2. Varias asociaciones TCP wire outbound concurrentes (hoy: un `g_out`).
+3. Multicast real (`IP_ADD_MEMBERSHIP`) — hoy `IP_MULTICAST_IF` solo fija src/bind.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IR0 is a research operating-system kernel (GPL-3.0). Primary bring-up target is
 **x86-64** under QEMU (Multiboot, GRUB, VFS/MINIX, ELF userspace). Version
-string: **`0.0.1-pre-rc3`**.
+string: **`0.0.1-rc4`** (last pre-release before `v0.0.1` final).
 
 It is not a general-purpose production OS. The tree emphasizes narrow facades
 (`includes/ir0/`), Kconfig selection, and honest partial Linux ABI (`-ENOSYS`

--- a/drivers/net/rtl8139.c
+++ b/drivers/net/rtl8139.c
@@ -393,9 +393,13 @@ static int32_t rtl8139_hw_init(void)
     resource_register_irq(irq, "rtl8139");
     resource_register_ioport(rtl8139_io_base, (uint16_t)(rtl8139_io_base + 0x40), "rtl8139");
 
-    /* Read Link Status (REAL DATA) */
+    /*
+     * MSR bit2 is LinkFail (datasheet / QEMU): 0 = link OK, 1 = down.
+     * QEMU user-net keeps the link up; inverted polarity left eth0 without
+     * IFF_UP so plain `ifconfig` (no -a) printed nothing.
+     */
     uint8_t msr = inb(rtl8139_io_base + RTL8139_REG_MSR);
-    bool link_ok = (msr & RTL8139_MSR_LINKB) != 0;
+    bool link_ok = (msr & RTL8139_MSR_LINKB) == 0;
 
     /* Register with network stack */
     memset(&rtl8139_dev, 0, sizeof(rtl8139_dev));
@@ -875,12 +879,14 @@ static void rtl8139_process_rx_packets(void)
         return;
     }
 
-    /* Read hardware write pointer
-     * In RTL8139, the write pointer is at offset 0x10 in the RX buffer
-     * We need to read it as a 16-bit value in little-endian format
+    /*
+     * Hardware write cursor is CBR (I/O 0x3A), not rx_buffer+0x10.
+     * Reading the ring as a write ptr desyncs CAPR under load → RxOverflow
+     * and RX stays wedged (TX still works; ping/wget die after stress).
+     * Spec: Realtek RTL8139 programming guide / datasheet CBR/CAPR.
      */
-    uint16_t current_write = *((volatile uint16_t *)(rtl8139_rx_buffer + 0x10));
-    current_write &= (RTL8139_RX_BUF_SIZE - 1);  /* Mask to buffer size */
+    uint16_t current_write = inw(rtl8139_io_base + RTL8139_REG_CBR);
+    current_write &= (RTL8139_RX_BUF_SIZE - 1);
     
     /* Handle wrap-around: if current_write < read_offset, we wrapped */
     if (current_write < rtl8139_rx_read_offset)
@@ -1128,40 +1134,37 @@ void rtl8139_handle_interrupt(void)
                    (unsigned)isr);
 #endif
     
-    /* Check for receive interrupt */
-    if (isr & RTL8139_INT_ROK)
+    /*
+     * ROK and RxBufOvw both need drain + CAPR update. Realtek: on overflow,
+     * update CAPR first then clear ISR(ROK); otherwise RX DMA stays stopped.
+     */
+    if (isr & (RTL8139_INT_ROK | RTL8139_INT_RXOVW | RTL8139_INT_FIFOOVW))
     {
+        if (isr & (RTL8139_INT_RXOVW | RTL8139_INT_FIFOOVW))
+        {
+            rtl8139_counters.rx_errors++;
+            LOG_WARNING_FMT("RTL8139", "RX overflow ISR=0x%x — draining ring",
+                            (unsigned)isr);
+        }
         if (rtl8139_try_enter_rx())
         {
-            LOG_DEBUG("RTL8139", "RX interrupt detected, processing packets...");
-            /* Process packets BEFORE clearing ISR to avoid race conditions */
             rtl8139_process_rx_packets();
             rtl8139_leave_rx();
         }
     }
-    else if (isr != 0)
+
+    if (isr & RTL8139_INT_RER)
     {
-        /* Log non-RX interrupts for debugging */
-        if (isr & RTL8139_INT_RER)
-        {
-            rtl8139_counters.rx_errors++;
-            LOG_DEBUG("RTL8139", "RX error interrupt");
-        }
-        if (isr & RTL8139_INT_RXOVW)
-        {
-            rtl8139_counters.rx_errors++;
-            LOG_WARNING("RTL8139", "RX buffer overflow interrupt");
-        }
-        if (isr & RTL8139_INT_TER)
-        {
-            rtl8139_counters.tx_errors++;
-            LOG_DEBUG("RTL8139", "TX error interrupt");
-        }
-        if (isr & RTL8139_INT_PUN)
-            LOG_DEBUG("RTL8139", "Packet underrun interrupt");
-        if (isr & RTL8139_INT_FIFOOVW)
-            LOG_WARNING("RTL8139", "FIFO overflow interrupt");
+        rtl8139_counters.rx_errors++;
+        LOG_DEBUG("RTL8139", "RX error interrupt");
     }
+    if (isr & RTL8139_INT_TER)
+    {
+        rtl8139_counters.tx_errors++;
+        LOG_DEBUG("RTL8139", "TX error interrupt");
+    }
+    if (isr & RTL8139_INT_PUN)
+        LOG_DEBUG("RTL8139", "Packet underrun interrupt");
     
     /* Check for transmit interrupt (optional, for TX completion) */
     if (isr & RTL8139_INT_TOK)
@@ -1212,7 +1215,7 @@ void rtl8139_poll(void)
     poll_count++;
     if ((poll_count % 500) == 0)
     {
-        uint16_t current_write = *((volatile uint16_t *)(rtl8139_rx_buffer + 0x10));
+        uint16_t current_write = inw(rtl8139_io_base + RTL8139_REG_CBR);
 
         current_write &= (RTL8139_RX_BUF_SIZE - 1);
         klog_debug_fmt("RTL8139",
@@ -1222,22 +1225,20 @@ void rtl8139_poll(void)
     }
 #endif
     
-    if (isr & RTL8139_INT_ROK)
+    if (isr & (RTL8139_INT_ROK | RTL8139_INT_RXOVW | RTL8139_INT_FIFOOVW))
     {
         if (rtl8139_try_enter_rx())
         {
-            /* Process packets */
             rtl8139_process_rx_packets();
             rtl8139_leave_rx();
-            
-            /* Clear interrupt status */
-            outw(rtl8139_io_base + RTL8139_REG_ISR, RTL8139_INT_ROK);
+            outw(rtl8139_io_base + RTL8139_REG_ISR,
+                 (uint16_t)(isr & (RTL8139_INT_ROK | RTL8139_INT_RXOVW |
+                                   RTL8139_INT_FIFOOVW)));
         }
     }
     else
     {
         /* Even if ISR doesn't show ROK, check the buffer directly */
-        /* Sometimes packets arrive but interrupt doesn't fire */
         if (rtl8139_try_enter_rx())
         {
             rtl8139_process_rx_packets();

--- a/drivers/net/rtl8139.h
+++ b/drivers/net/rtl8139.h
@@ -48,6 +48,7 @@
 #define RTL8139_REG_RBSTART 0x30 /* Receive Buffer Start Address */
 #define RTL8139_REG_CR 0x37      /* Command Register */
 #define RTL8139_REG_CAPR 0x38    /* Current Address of Packet Read */
+#define RTL8139_REG_CBR 0x3A     /* Current Buffer Address (RX write ptr) */
 #define RTL8139_REG_IMR 0x3C     /* Interrupt Mask Register */
 #define RTL8139_REG_ISR 0x3E     /* Interrupt Status Register */
 #define RTL8139_REG_TCR 0x40     /* Transmit Configuration Register */
@@ -56,7 +57,7 @@
 #define RTL8139_REG_MSR     0x58 /* Media Status Register */
 
 /* Media Status Register bits */
-#define RTL8139_MSR_LINKB   (1 << 2) /* Link Status (0=Fail, 1=OK) */
+#define RTL8139_MSR_LINKB   (1 << 2) /* LinkFail: 1=down, 0=up (Realtek MSR) */
 #define RTL8139_MSR_SPEED   (1 << 3) /* Speed (0=10M, 1=100M) */
 #define RTL8139_MSR_AUX     (1 << 4) /* Aux. Power Status */
 

--- a/fs/procfs.c
+++ b/fs/procfs.c
@@ -168,9 +168,13 @@ int proc_net_dev_read(char *buf, size_t count)
         return -1;
     memset(buf, 0, count);
     size_t off = 0;
+    /*
+     * Linux /proc/net/dev columns (BusyBox interface.c procnetdev_vsn=2).
+     * Header must contain "bytes" and "compressed" for fancy ifconfig stats.
+     */
     int n = snprintf(buf, count,
                      "Inter-|   Receive                                                |  Transmit\n"
-                     " face |   packets    errs                                        |  packets    errs\n");
+                     " face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed\n");
     if (n < 0)
         return -1;
     if ((size_t)n >= count)
@@ -184,21 +188,30 @@ int proc_net_dev_read(char *buf, size_t count)
     while (dev && off < count - 1)
     {
         uint64_t rxp = 0, txp = 0, rxe = 0, txe = 0;
+        uint64_t rxb = 0, txb = 0;
         char rxp_str[24];
         char rxe_str[24];
         char txp_str[24];
         char txe_str[24];
+        char rxb_str[24];
+        char txb_str[24];
 
         if (dev->get_stats)
             dev->get_stats(dev, &rxp, &txp, &rxe, &txe);
+        if (dev->get_byte_stats)
+            dev->get_byte_stats(dev, &rxb, &txb);
 
+        proc_u64_to_dec(rxb, rxb_str, sizeof(rxb_str));
         proc_u64_to_dec(rxp, rxp_str, sizeof(rxp_str));
         proc_u64_to_dec(rxe, rxe_str, sizeof(rxe_str));
+        proc_u64_to_dec(txb, txb_str, sizeof(txb_str));
         proc_u64_to_dec(txp, txp_str, sizeof(txp_str));
         proc_u64_to_dec(txe, txe_str, sizeof(txe_str));
-        n = snprintf(buf + off, count - off, "  %s: %s %s                                          %s %s\n",
+        /* bytes packets errs drop fifo frame compressed multicast | tx... */
+        n = snprintf(buf + off, count - off,
+                     "  %s: %s %s %s 0 0 0 0 0 %s %s %s 0 0 0 0 0\n",
                      (dev->name && dev->name[0] != '\0') ? dev->name : "eth0",
-                     rxp_str, rxe_str, txp_str, txe_str);
+                     rxb_str, rxp_str, rxe_str, txb_str, txp_str, txe_str);
         if (n < 0)
             return -1;
         if ((size_t)n >= count - off)

--- a/includes/ir0/net.h
+++ b/includes/ir0/net.h
@@ -63,11 +63,21 @@ static inline ip4_addr_t make_ip4_addr(uint8_t a, uint8_t b, uint8_t c, uint8_t 
 
 /* --- Networking Abstraction Layer --- */
 
-/* Standard Network Device Flags */
-#define IFF_UP (1 << 0)        /* Interface is up */
-#define IFF_BROADCAST (1 << 1) /* Broadcast address valid */
-#define IFF_LOOPBACK (1 << 2)  /* Is a loopback net */
-#define IFF_RUNNING (1 << 3)   /* Interface is running */
+/*
+ * Linux uapi netdevice flags (include/uapi/linux/if.h).
+ * BusyBox ifconfig/route interpret these bits; IR0 must match.
+ */
+#define IFF_UP          0x1
+#define IFF_BROADCAST   0x2
+#define IFF_DEBUG       0x4
+#define IFF_LOOPBACK    0x8
+#define IFF_POINTOPOINT 0x10
+#define IFF_NOTRAILERS  0x20
+#define IFF_RUNNING     0x40
+#define IFF_NOARP       0x80
+#define IFF_PROMISC     0x100
+#define IFF_ALLMULTI    0x200
+#define IFF_MULTICAST   0x1000
 
 struct net_device
 {
@@ -167,6 +177,7 @@ int ip_route_walk(int (*cb)(ip4_addr_t dest, ip4_addr_t mask, ip4_addr_t gw,
 			     void *ctx),
 		  void *ctx);
 int ip_route_add(ip4_addr_t dest_network, ip4_addr_t netmask, ip4_addr_t gateway);
+int ip_route_del(ip4_addr_t dest_network, ip4_addr_t netmask);
 int ip_routes_seed_from_globals(void);
 
 /* ICMP helpers used by /dev/net control plane. */

--- a/includes/ir0/signals.c
+++ b/includes/ir0/signals.c
@@ -593,6 +593,13 @@ void handle_signals(void)
             {
                 /* Call userspace handler */
                 void (*handler)(int) = current->signal_handlers[sig];
+
+		/*
+		 * Defer catchable delivery: leave pending for the in-syscall
+		 * wait to return -EINTR/-ETIMEDOUT (see signal_defer_catchable).
+		 */
+		if (current->signal_defer_catchable)
+			continue;
                 
                 /* Validate handler is in userspace */
                 if (is_user_address((void *)handler, sizeof(void *)))

--- a/includes/ir0/sock_icmp.h
+++ b/includes/ir0/sock_icmp.h
@@ -26,6 +26,10 @@ void sock_icmp_release(struct sock_icmp *sock);
 
 int sock_icmp_is(const void *ptr);
 
+int sock_icmp_bind(struct sock_icmp *sock, uint32_t local_ip_be);
+int sock_icmp_set_ttl(struct sock_icmp *sock, int ttl);
+int sock_icmp_set_bind_device(struct sock_icmp *sock, const char *name, size_t len);
+
 int sock_icmp_poll_readable(struct sock_icmp *sock);
 
 int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,

--- a/includes/ir0/sock_inet_ioctl.h
+++ b/includes/ir0/sock_inet_ioctl.h
@@ -7,7 +7,7 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: sock_inet_ioctl.h
- * Description: Minimal Linux SIOCGIF* ioctls for BusyBox ifconfig (AF_INET sockets).
+ * Description: Linux SIOCGIF and SIOCSIF plus SIOCADDRT/SIOCDELRT for BusyBox.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -18,16 +18,30 @@
 #include <ir0/types.h>
 
 /*
- * Linux x86-64 sockios.h request numbers (read-only subset for ifconfig -a).
+ * Linux x86-64 sockios.h request numbers.
  * Source: include/uapi/linux/sockios.h
  */
+#define IR0_SIOCADDRT     0x890B
+#define IR0_SIOCDELRT     0x890C
+#define IR0_SIOCGIFNAME   0x8910
 #define IR0_SIOCGIFCONF   0x8912
 #define IR0_SIOCGIFFLAGS  0x8913
+#define IR0_SIOCSIFFLAGS  0x8914
 #define IR0_SIOCGIFADDR   0x8915
+#define IR0_SIOCSIFADDR   0x8916
+#define IR0_SIOCSIFDSTADDR 0x8918
 #define IR0_SIOCGIFBRDADDR 0x8919
+#define IR0_SIOCSIFBRDADDR 0x891a
 #define IR0_SIOCGIFNETMASK 0x891b
+#define IR0_SIOCSIFNETMASK 0x891c
+#define IR0_SIOCGIFMETRIC 0x891d
+#define IR0_SIOCSIFMETRIC 0x891e
 #define IR0_SIOCGIFMTU    0x8921
+#define IR0_SIOCSIFMTU    0x8922
+#define IR0_SIOCSIFHWADDR 0x8924
 #define IR0_SIOCGIFHWADDR 0x8927
 #define IR0_SIOCGIFINDEX  0x8933
+#define IR0_SIOCGIFTXQLEN 0x8942
+#define IR0_SIOCSIFTXQLEN 0x8943
 
 int64_t sock_inet_ioctl(uint64_t request, void *arg);

--- a/includes/ir0/socket.h
+++ b/includes/ir0/socket.h
@@ -35,7 +35,12 @@
 #define SO_REUSEADDR 2
 #define SO_RCVTIMEO 20
 #define SO_SNDTIMEO 21
+#define SO_BINDTODEVICE 25
 #define SCM_RIGHTS  1
+
+#define IPPROTO_IP  0
+#define IP_TTL      2
+#define IP_MULTICAST_IF 32
 
 #define MSG_PEEK     0x2
 #define MSG_DONTWAIT 0x40

--- a/includes/ir0/version.h
+++ b/includes/ir0/version.h
@@ -45,8 +45,8 @@
 #define IR0_VERSION_MAJOR 0
 #define IR0_VERSION_MINOR 0
 #define IR0_VERSION_PATCH 1
-#define IR0_VERSION_SUFFIX "-pre-rc3"
-#define IR0_VERSION_STRING "0.0.1-pre-rc3"
+#define IR0_VERSION_SUFFIX "-rc4"
+#define IR0_VERSION_STRING "0.0.1-rc4"
 
 /* Build information macros */
 /* If passed from Makefile, use those (real data), otherwise use compiler defaults */

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -224,6 +224,13 @@ typedef struct process
 	 * (sendto/setitimer from BusyBox ping SIGALRM) re-enter the handler.
 	 */
 	uint8_t signal_enter_pending;
+	/*
+	 * When set, handle_signals() leaves catchable user handlers pending
+	 * (no sigframe / signal_enter_pending). Interruptible waits (e.g.
+	 * tcp_wire_connect) can map SIGALRM → -ETIMEDOUT instead of jumping
+	 * into BusyBox die-from-handler (exit from SIGALRM SEGVs on repeat).
+	 */
+	uint8_t signal_defer_catchable;
 
 	/* Linux syscall insn frame (for fork child / blocked syscall return). */
 	arch_syscall_frame_t syscall_frame;

--- a/kernel/process/create.c
+++ b/kernel/process/create.c
@@ -255,6 +255,7 @@ pid_t spawn(void (*entry)(void), const char *name, process_mode_t mode)
 	proc->signal_ignored = 0;
 	proc->saved_context = NULL;
 	proc->signal_enter_pending = 0;
+	proc->signal_defer_catchable = 0;
 	for (int i = 0; i < _NSIG; i++)
 	{
 		proc->signal_handlers[i] = SIG_DFL;

--- a/kernel/process/domains.c
+++ b/kernel/process/domains.c
@@ -58,6 +58,7 @@ int process_signals_clone(process_t *dst, const process_t *src)
 	}
 	dst->saved_context = NULL;
 	dst->signal_enter_pending = 0;
+	dst->signal_defer_catchable = 0;
 	return 0;
 }
 

--- a/kernel/process/exit.c
+++ b/kernel/process/exit.c
@@ -17,6 +17,10 @@
 #include <ir0/copy_user.h>
 #include <ir0/ktm/checkpoint.h>
 
+#if CONFIG_ENABLE_NETWORKING
+void tcp_wire_on_process_exit(uint32_t pid);
+#endif
+
 /*
  * Teardown ownership policy
  * -------------------------
@@ -66,6 +70,10 @@ __attribute__((noreturn)) void process_exit(int code)
 	}
 	process_fase50_trace_proc("process_exit-entry", dying);
 	dying->irq_frame_saved = 0;
+	dying->signal_defer_catchable = 0;
+#if CONFIG_ENABLE_NETWORKING
+	tcp_wire_on_process_exit((uint32_t)dying->task.pid);
+#endif
 	process_exit_robust_list(dying);
 	if (IR0_DEBUG_WAIT)
 		klog_debug("WAIT", "CLASSIFY ZOMBIE_IRQ_SAVED_CLEARED");

--- a/kernel/sock_icmp.c
+++ b/kernel/sock_icmp.c
@@ -48,6 +48,9 @@ struct sock_icmp
 	struct sock_icmp_rx_pkt *rx_head;
 	struct sock_icmp_rx_pkt *rx_tail;
 	size_t rx_count;
+	ip4_addr_t bind_ip; /* 0 = any; set by bind() for ping -I addr */
+	uint8_t ttl;        /* 0 = default 64; IP_TTL */
+	char bind_dev[16];  /* SO_BINDTODEVICE name (advisory on single-NIC) */
 };
 
 static struct sock_icmp *sock_icmp_open_list;
@@ -266,6 +269,61 @@ void sock_icmp_release(struct sock_icmp *sock)
 	kfree(sock);
 }
 
+int sock_icmp_bind(struct sock_icmp *sock, uint32_t local_ip_be)
+{
+	if (!sock || !sock_icmp_is(sock))
+		return -EINVAL;
+	sock->bind_ip = local_ip_be;
+	return 0;
+}
+
+int sock_icmp_set_ttl(struct sock_icmp *sock, int ttl)
+{
+	if (!sock || !sock_icmp_is(sock))
+		return -EINVAL;
+	if (ttl < 0 || ttl > 255)
+		return -EINVAL;
+	sock->ttl = (uint8_t)ttl;
+	return 0;
+}
+
+int sock_icmp_set_bind_device(struct sock_icmp *sock, const char *name, size_t len)
+{
+	size_t n;
+	struct net_device *d;
+	int found = 0;
+
+	if (!sock || !sock_icmp_is(sock))
+		return -EINVAL;
+	if (!name || len == 0)
+	{
+		sock->bind_dev[0] = '\0';
+		return 0;
+	}
+	n = len;
+	if (n >= sizeof(sock->bind_dev))
+		n = sizeof(sock->bind_dev) - 1;
+	memcpy(sock->bind_dev, name, n);
+	sock->bind_dev[n] = '\0';
+
+	d = net_get_devices();
+	while (d)
+	{
+		if (d->name && strcmp(d->name, sock->bind_dev) == 0)
+		{
+			found = 1;
+			break;
+		}
+		d = d->next;
+	}
+	if (!found)
+	{
+		sock->bind_dev[0] = '\0';
+		return -ENODEV;
+	}
+	return 0;
+}
+
 int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,
 		     const void *data, size_t len)
 {
@@ -279,6 +337,7 @@ int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,
 	struct net_device *dev;
 	ip4_addr_t dest_ip = dest_ip_be;
 	int ret;
+	uint8_t ttl;
 
 	if (!sock || !data)
 		return -EINVAL;
@@ -290,8 +349,23 @@ int sock_icmp_sendto(struct sock_icmp *sock, uint32_t dest_ip_be,
 	dev = net_get_devices();
 	if (!dev)
 		return -ENETUNREACH;
+	if (sock->bind_dev[0])
+	{
+		struct net_device *d = net_get_devices();
 
-	ret = ip_send(dev, dest_ip, IPPROTO_ICMP, data, len);
+		while (d)
+		{
+			if (d->name && strcmp(d->name, sock->bind_dev) == 0)
+			{
+				dev = d;
+				break;
+			}
+			d = d->next;
+		}
+	}
+
+	ttl = sock->ttl ? sock->ttl : 64;
+	ret = ip_send_ttl(dev, dest_ip, IPPROTO_ICMP, data, len, ttl);
 	if (ret != 0)
 		return -EIO;
 	return (int)len;

--- a/kernel/sock_inet_ioctl.c
+++ b/kernel/sock_inet_ioctl.c
@@ -7,7 +7,7 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: sock_inet_ioctl.c
- * Description: Linux-compatible SIOCGIF* for BusyBox ifconfig (read-only).
+ * Description: Linux-compatible SIOCGIF and SIOCSIF plus route ioctls for BusyBox.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -53,7 +53,31 @@ struct ir0_ifconf
 	} ifc_ifcu;
 };
 
+/*
+ * Linux x86-64 struct rtentry (120 bytes). Offsets verified against glibc
+ * <net/route.h>: dst=8 gw=24 genmask=40 flags=56.
+ */
+struct ir0_rtentry
+{
+	unsigned long rt_pad1;
+	struct ir0_sockaddr rt_dst;
+	struct ir0_sockaddr rt_gateway;
+	struct ir0_sockaddr rt_genmask;
+	unsigned short rt_flags;
+	short rt_pad2;
+	unsigned long rt_pad3;
+	void *rt_pad4;
+	short rt_metric;
+	char *rt_dev;
+	unsigned long rt_mtu;
+	unsigned long rt_window;
+	unsigned short rt_irtt;
+};
+
 #if CONFIG_ENABLE_NETWORKING
+
+static ip4_addr_t g_ip_broadcast;
+static int g_ip_broadcast_set;
 
 static struct net_device *sock_find_dev(const char *name)
 {
@@ -82,8 +106,17 @@ static void sock_fill_sockaddr_in(struct ir0_sockaddr *sa, ip4_addr_t ip_be)
 {
 	memset(sa, 0, sizeof(*sa));
 	sa->sa_family = IR0_AF_INET;
-	/* sockaddr_in: family(2) port(2) addr(4) — store addr at sa_data+2 */
 	memcpy(sa->sa_data + 2, &ip_be, sizeof(ip_be));
+}
+
+static ip4_addr_t sock_sockaddr_in_addr(const struct ir0_sockaddr *sa)
+{
+	ip4_addr_t ip = 0;
+
+	if (!sa)
+		return 0;
+	memcpy(&ip, sa->sa_data + 2, sizeof(ip));
+	return ip;
 }
 
 static ip4_addr_t sock_dev_ip(struct net_device *dev)
@@ -96,6 +129,27 @@ static ip4_addr_t sock_dev_netmask(struct net_device *dev)
 {
 	(void)dev;
 	return ip_netmask;
+}
+
+static ip4_addr_t sock_dev_bcast(struct net_device *dev)
+{
+	ip4_addr_t ip;
+	ip4_addr_t nm;
+
+	if (g_ip_broadcast_set)
+		return g_ip_broadcast;
+	ip = sock_dev_ip(dev);
+	nm = sock_dev_netmask(dev);
+	return ip | ~nm;
+}
+
+static void sock_apply_iface_ip(struct net_device *dev)
+{
+	if (!dev)
+		return;
+	arp_set_my_ip(ip_local_addr);
+	(void)arp_set_interface_ip(dev, ip_local_addr);
+	(void)ip_routes_seed_from_globals();
 }
 
 static int sock_siocgifconf(void *arg)
@@ -154,6 +208,52 @@ static int sock_siocgifconf(void *arg)
 	return 0;
 }
 
+static int g_if_metric;
+static int g_if_txqlen = 1000;
+
+static int sock_siocgifname(void *arg)
+{
+	struct ir0_ifreq ifr;
+	struct net_device *dev;
+	int want;
+	int idx;
+
+	if (!arg)
+		return -EINVAL;
+	if (copy_from_user(&ifr, arg, sizeof(ifr)) != 0)
+		return -EFAULT;
+
+	want = ifr.ifr_ifru.ivalue;
+	if (want < 1)
+		return -ENODEV;
+
+	idx = 1;
+	dev = net_get_devices();
+	while (dev)
+	{
+		if (idx == want)
+		{
+			memset(ifr.ifr_name, 0, sizeof(ifr.ifr_name));
+			if (dev->name)
+			{
+				size_t n = 0;
+
+				while (n < IR0_IFNAMSIZ - 1 && dev->name[n])
+				{
+					ifr.ifr_name[n] = dev->name[n];
+					n++;
+				}
+			}
+			if (copy_to_user(arg, &ifr, sizeof(ifr)) != 0)
+				return -EFAULT;
+			return 0;
+		}
+		idx++;
+		dev = dev->next;
+	}
+	return -ENODEV;
+}
+
 static int sock_siocgif_one(uint64_t request, void *arg)
 {
 	struct ir0_ifreq ifr;
@@ -174,7 +274,7 @@ static int sock_siocgif_one(uint64_t request, void *arg)
 
 	ip = sock_dev_ip(dev);
 	nm = sock_dev_netmask(dev);
-	bcast = ip | ~nm;
+	bcast = sock_dev_bcast(dev);
 
 	switch (request)
 	{
@@ -213,6 +313,12 @@ static int sock_siocgif_one(uint64_t request, void *arg)
 		}
 		ifr.ifr_ifru.ivalue = idx;
 		break;
+	case IR0_SIOCGIFMETRIC:
+		ifr.ifr_ifru.ivalue = g_if_metric;
+		break;
+	case IR0_SIOCGIFTXQLEN:
+		ifr.ifr_ifru.ivalue = g_if_txqlen;
+		break;
 	default:
 		return -ENOTTY;
 	}
@@ -222,12 +328,107 @@ static int sock_siocgif_one(uint64_t request, void *arg)
 	return 0;
 }
 
+static int sock_siocsif_one(uint64_t request, void *arg)
+{
+	struct ir0_ifreq ifr;
+	struct net_device *dev;
+	ip4_addr_t ip;
+
+	if (!arg)
+		return -EINVAL;
+	if (copy_from_user(&ifr, arg, sizeof(ifr)) != 0)
+		return -EFAULT;
+
+	dev = sock_find_dev(ifr.ifr_name);
+	if (!dev)
+		return -ENODEV;
+
+	switch (request)
+	{
+	case IR0_SIOCSIFFLAGS:
+		dev->flags = (uint32_t)(unsigned short)ifr.ifr_ifru.flags;
+		if (dev->flags & IFF_UP)
+			dev->flags |= IFF_RUNNING;
+		break;
+	case IR0_SIOCSIFADDR:
+		ip = sock_sockaddr_in_addr(&ifr.ifr_ifru.addr);
+		ip_local_addr = ip;
+		sock_apply_iface_ip(dev);
+		break;
+	case IR0_SIOCSIFNETMASK:
+		ip_netmask = sock_sockaddr_in_addr(&ifr.ifr_ifru.addr);
+		sock_apply_iface_ip(dev);
+		break;
+	case IR0_SIOCSIFBRDADDR:
+		g_ip_broadcast = sock_sockaddr_in_addr(&ifr.ifr_ifru.addr);
+		g_ip_broadcast_set = 1;
+		break;
+	case IR0_SIOCSIFDSTADDR:
+		/* Point-to-point peer — store as gateway hint when non-zero. */
+		ip = sock_sockaddr_in_addr(&ifr.ifr_ifru.addr);
+		if (ip)
+			ip_gateway = ip;
+		break;
+	case IR0_SIOCSIFMTU:
+		if (ifr.ifr_ifru.mtu < 68 || ifr.ifr_ifru.mtu > 65535)
+			return -EINVAL;
+		dev->mtu = (size_t)ifr.ifr_ifru.mtu;
+		break;
+	case IR0_SIOCSIFHWADDR:
+		memcpy(dev->mac, ifr.ifr_ifru.addr.sa_data, 6);
+		break;
+	case IR0_SIOCSIFMETRIC:
+		g_if_metric = ifr.ifr_ifru.ivalue;
+		break;
+	case IR0_SIOCSIFTXQLEN:
+		g_if_txqlen = ifr.ifr_ifru.ivalue;
+		break;
+	default:
+		return -ENOTTY;
+	}
+	return 0;
+}
+
+static int sock_sioc_rt(uint64_t request, void *arg)
+{
+	struct ir0_rtentry rt;
+	ip4_addr_t dst;
+	ip4_addr_t gw;
+	ip4_addr_t mask;
+	int ret;
+
+	if (!arg)
+		return -EINVAL;
+	if (copy_from_user(&rt, arg, sizeof(rt)) != 0)
+		return -EFAULT;
+
+	dst = sock_sockaddr_in_addr(&rt.rt_dst);
+	gw = sock_sockaddr_in_addr(&rt.rt_gateway);
+	mask = sock_sockaddr_in_addr(&rt.rt_genmask);
+
+	if (request == IR0_SIOCADDRT)
+	{
+		if (gw)
+			ip_gateway = gw;
+		ret = ip_route_add(dst, mask, gw);
+		return (ret == 0) ? 0 : -ENOMEM;
+	}
+	if (request == IR0_SIOCDELRT)
+	{
+		ret = ip_route_del(dst, mask);
+		return (ret == 0) ? 0 : -ESRCH;
+	}
+	return -ENOTTY;
+}
+
 int64_t sock_inet_ioctl(uint64_t request, void *arg)
 {
 	switch (request)
 	{
 	case IR0_SIOCGIFCONF:
 		return sock_siocgifconf(arg);
+	case IR0_SIOCGIFNAME:
+		return sock_siocgifname(arg);
 	case IR0_SIOCGIFFLAGS:
 	case IR0_SIOCGIFADDR:
 	case IR0_SIOCGIFBRDADDR:
@@ -235,7 +436,22 @@ int64_t sock_inet_ioctl(uint64_t request, void *arg)
 	case IR0_SIOCGIFMTU:
 	case IR0_SIOCGIFHWADDR:
 	case IR0_SIOCGIFINDEX:
+	case IR0_SIOCGIFMETRIC:
+	case IR0_SIOCGIFTXQLEN:
 		return sock_siocgif_one(request, arg);
+	case IR0_SIOCSIFFLAGS:
+	case IR0_SIOCSIFADDR:
+	case IR0_SIOCSIFDSTADDR:
+	case IR0_SIOCSIFBRDADDR:
+	case IR0_SIOCSIFNETMASK:
+	case IR0_SIOCSIFMTU:
+	case IR0_SIOCSIFHWADDR:
+	case IR0_SIOCSIFMETRIC:
+	case IR0_SIOCSIFTXQLEN:
+		return sock_siocsif_one(request, arg);
+	case IR0_SIOCADDRT:
+	case IR0_SIOCDELRT:
+		return sock_sioc_rt(request, arg);
 	default:
 		return -ENOTTY;
 	}

--- a/kernel/sock_stream.c
+++ b/kernel/sock_stream.c
@@ -157,6 +157,10 @@ struct sock_stream *sock_stream_get_peer(struct sock_stream *s)
 
 static int sock_stream_wire_progress(struct sock_stream *s)
 {
+#if !CONFIG_ENABLE_NETWORKING
+	(void)s;
+	return 0;
+#else
 	uint32_t seq;
 	uint32_t ack;
 	int ret;
@@ -181,6 +185,7 @@ static int sock_stream_wire_progress(struct sock_stream *s)
 	s->so_error = 0;
 	poll_wake_check();
 	return 1;
+#endif
 }
 
 int sock_stream_poll_readable(const struct sock_stream *s)

--- a/kernel/syscalls/socket_syscalls.c
+++ b/kernel/syscalls/socket_syscalls.c
@@ -249,10 +249,29 @@ int64_t sys_socket(int domain, int type, int protocol)
 		return fd;
 	}
 
-	if (domain != AF_INET)
-		return -EAFNOSUPPORT;
 	if (base != SOCK_DGRAM)
 		return -EPROTOTYPE;
+
+	/*
+	 * AF_UNIX SOCK_DGRAM: musl if_nametoindex()/if_indextoname() open
+	 * AF_UNIX datagram sockets solely for SIOCGIFINDEX/SIOCGIFNAME.
+	 * Reuse a UDP sock object as an ioctl control fd (no wire I/O).
+	 */
+	if (domain == AF_UNIX)
+	{
+		struct sock_udp *sock;
+
+		if (protocol != 0)
+			return -EPROTONOSUPPORT;
+		sock = sock_udp_create();
+		if (!sock)
+			return -ENOMEM;
+		fd = sock_alloc_fd_flags(sock, 0, type_flags);
+		return fd;
+	}
+
+	if (domain != AF_INET)
+		return -EAFNOSUPPORT;
 	if (protocol != 0 && protocol != IPPROTO_UDP)
 		return -EPROTONOSUPPORT;
 
@@ -325,6 +344,7 @@ int64_t sys_bind(int fd, const struct sockaddr *addr, socklen_t addrlen)
 	}
 
 	{
+		struct sock_icmp *icmp;
 		struct sockaddr_in sin;
 
 		if (addrlen < sizeof(struct sockaddr_in))
@@ -333,6 +353,11 @@ int64_t sys_bind(int fd, const struct sockaddr *addr, socklen_t addrlen)
 			return -EFAULT;
 		if (sin.sin_family != AF_INET)
 			return -EAFNOSUPPORT;
+
+		icmp = sock_icmp_fd_lookup(fd);
+		if (icmp)
+			return sock_icmp_bind(icmp, sin.sin_addr);
+
 		sock = sock_fd_lookup(fd);
 		if (!sock)
 			return -ENOTSOCK;
@@ -569,21 +594,9 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 				handle_signals();
 				kfree(kbuf);
 				/*
-				 * Sysret would return to the insn after recvfrom and
-				 * ignore task.RIP. If a userspace handler was armed,
-				 * iretq into it (BusyBox ping SIGALRM → sendping4).
+				 * Leave signal_enter_pending for syscall_dispatch
+				 * (same as tcp_wire_connect interrupt).
 				 */
-				if (current_process->saved_context &&
-				    current_process->signal_enter_pending)
-				{
-					current_process->signal_enter_pending = 0;
-					process_restore_user_task_segments(current_process);
-					current_process->irq_frame_saved = 0;
-					current_process->coop_resched_resume = 0;
-					current_process->want_kernel_ret = 0;
-					arch_restore_user_fs_base();
-					switch_to_user_task(&current_process->task);
-				}
 				return -EINTR;
 			}
 			{
@@ -599,17 +612,6 @@ ssize_t sys_recvfrom(int fd, void *buf, size_t len, int flags,
 			{
 				handle_signals();
 				kfree(kbuf);
-				if (current_process->saved_context &&
-				    current_process->signal_enter_pending)
-				{
-					current_process->signal_enter_pending = 0;
-					process_restore_user_task_segments(current_process);
-					current_process->irq_frame_saved = 0;
-					current_process->coop_resched_resume = 0;
-					current_process->want_kernel_ret = 0;
-					arch_restore_user_fs_base();
-					switch_to_user_task(&current_process->task);
-				}
 				return -EINTR;
 			}
 			icmp = sock_icmp_fd_lookup(fd);
@@ -1348,6 +1350,7 @@ int64_t sys_setsockopt(int fd, int level, int optname, const void *optval,
 		       socklen_t optlen)
 {
 	struct sock_stream *ss;
+	struct sock_icmp *icmp;
 	int val = 0;
 
 #if !CONFIG_ENABLE_NETWORKING
@@ -1359,6 +1362,68 @@ int64_t sys_setsockopt(int fd, int level, int optname, const void *optval,
 	return -ENOSYS;
 #endif
 	ss = sock_stream_fd_lookup(fd);
+	icmp = sock_icmp_fd_lookup(fd);
+
+	if (icmp)
+	{
+		if (level == IPPROTO_IP && optname == IP_TTL)
+		{
+			if (optlen < sizeof(int) || !optval)
+				return -EINVAL;
+			if (copy_from_user(&val, optval, sizeof(val)) != 0)
+				return -EFAULT;
+			return sock_icmp_set_ttl(icmp, val);
+		}
+		if (level == IPPROTO_IP && optname == IP_MULTICAST_IF)
+		{
+			/*
+			 * BusyBox ping -I <addr> passes sockaddr_in (16B). Linux
+			 * treats optlen>=12 as ip_mreqn; imr_address sits at
+			 * offset 4 — same as sin_addr in sockaddr_in.
+			 */
+			uint8_t buf[16];
+			uint32_t addr = 0;
+			size_t n;
+
+			if (!optval || optlen < 4)
+				return -EINVAL;
+			n = optlen;
+			if (n > sizeof(buf))
+				n = sizeof(buf);
+			memset(buf, 0, sizeof(buf));
+			if (copy_from_user(buf, optval, n) != 0)
+				return -EFAULT;
+			if (n >= 8)
+				memcpy(&addr, buf + 4, 4);
+			else
+				memcpy(&addr, buf, 4);
+			return sock_icmp_bind(icmp, addr);
+		}
+		if (level == SOL_SOCKET && optname == SO_BINDTODEVICE)
+		{
+			char name[16];
+			size_t n;
+			size_t i;
+
+			if (!optval || optlen == 0)
+				return sock_icmp_set_bind_device(icmp, NULL, 0);
+			/*
+			 * Linux accepts a C string or struct ifreq (name at offset 0).
+			 * BusyBox setsockopt_bindtodevice() passes sizeof(ifreq).
+			 */
+			n = optlen;
+			if (n > sizeof(name))
+				n = sizeof(name);
+			memset(name, 0, sizeof(name));
+			if (copy_from_user(name, optval, n) != 0)
+				return -EFAULT;
+			for (i = 0; i < n && name[i]; i++)
+				;
+			return sock_icmp_set_bind_device(icmp, name, i);
+		}
+		return -ENOPROTOOPT;
+	}
+
 	if (!ss)
 		return -ENOTSOCK;
 	if (level != SOL_SOCKET)
@@ -1385,6 +1450,11 @@ int64_t sys_setsockopt(int fd, int level, int optname, const void *optval,
 		ms = (uint64_t)tv.tv_sec * 1000ULL +
 		     (uint64_t)tv.tv_usec / 1000ULL;
 		return sock_stream_set_timeout_ms(ss, optname == SO_RCVTIMEO, ms);
+	}
+	if (optname == SO_BINDTODEVICE)
+	{
+		/* Single-NIC stack: accept and ignore for STREAM. */
+		return 0;
 	}
 	return -ENOPROTOOPT;
 }

--- a/net/ip.c
+++ b/net/ip.c
@@ -373,7 +373,7 @@ void ip_receive_handler(struct net_device *dev, const void *data,
 static int ip_send_fragment(struct net_device *dev, ip4_addr_t dest_ip, 
                             uint8_t protocol, const void *payload, size_t len,
                             uint16_t frag_id, uint16_t frag_offset, bool more_fragments,
-                            ip4_addr_t next_hop_ip)
+                            ip4_addr_t next_hop_ip, uint8_t ttl)
 {
     size_t ip_header_len = sizeof(struct ip_header);
     size_t fragment_len = ip_header_len + len;
@@ -398,7 +398,7 @@ static int ip_send_fragment(struct net_device *dev, ip4_addr_t dest_ip,
         flags_frag |= IP_FLAG_MF;
     ip->flags_frag_off = htons(flags_frag);
     
-    ip->ttl = 64;
+    ip->ttl = ttl ? ttl : 64;
     ip->protocol = protocol;
     ip->checksum = 0;
     /* Source IP: use interface-specific IP if available, else default */
@@ -430,8 +430,14 @@ static int ip_send_fragment(struct net_device *dev, ip4_addr_t dest_ip,
     return ret;
 }
 
-int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol, 
+int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
             const void *payload, size_t len)
+{
+	return ip_send_ttl(dev, dest_ip, protocol, payload, len, 64);
+}
+
+int ip_send_ttl(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
+		const void *payload, size_t len, uint8_t ttl)
 {
     if (!dev || !payload)
         return -1;
@@ -545,7 +551,7 @@ int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
         uint16_t frag_id = ip_frag_id_counter++;
         ip->id = htons(frag_id);  /* Unique fragment ID */
         ip->flags_frag_off = 0;         /* No fragmentation flags (unfragmented packet) */
-        ip->ttl = 64;                    /* Time To Live: 64 hops */
+        ip->ttl = ttl ? ttl : 64;            /* Time To Live */
         ip->protocol = protocol;         /* Upper-layer protocol (ICMP, UDP) */
         ip->checksum = 0;                /* Zero for checksum calculation */
         /* Source IP: use interface-specific IP if available, else default */
@@ -622,7 +628,8 @@ int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
         /* Send fragment */
         int ret = ip_send_fragment(dev, dest_ip, protocol, 
                                    payload_ptr + offset, fragment_payload_len,
-                                   frag_id, offset, more_fragments, next_hop_ip);
+                                   frag_id, offset, more_fragments, next_hop_ip,
+				   ttl);
         
         if (ret != 0)
         {

--- a/net/ip.h
+++ b/net/ip.h
@@ -57,9 +57,11 @@ struct ip_rx_context
 
 /* IP Protocol API */
 int ip_init(void);
-int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol, 
+int ip_send(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
             const void *payload, size_t len);
-void ip_receive_handler(struct net_device *dev, const void *data, 
+int ip_send_ttl(struct net_device *dev, ip4_addr_t dest_ip, uint8_t protocol,
+		const void *payload, size_t len, uint8_t ttl);
+void ip_receive_handler(struct net_device *dev, const void *data,
                         size_t len, void *priv);
 
 /* Routing API */

--- a/net/tcp.c
+++ b/net/tcp.c
@@ -134,6 +134,32 @@ struct tcp_wire_outbound
 static struct tcp_pending_conn g_pending;
 static struct tcp_wire_listener g_listeners[TCP_WIRE_LISTEN_MAX];
 static struct tcp_wire_inbound g_inbound[TCP_WIRE_CONN_MAX];
+/* Serialize outbound connect: single g_pending/g_out (parallel wget → EINVAL). */
+static volatile int g_tcp_connect_busy;
+static uint32_t g_tcp_connect_owner;
+
+static int tcp_consume_connect_sigalrm(void)
+{
+	uint32_t pend;
+
+	if (!current_process)
+		return 0;
+	pend = current_process->signal_pending;
+	if ((pend & SIGNAL_MASK(SIGALRM)) == 0)
+		return 0;
+	if ((pend & ~(SIGNAL_MASK(SIGALRM) | SIGNAL_MASK(SIGCHLD))) != 0)
+		return 0;
+	current_process->signal_pending &= ~SIGNAL_MASK(SIGALRM);
+	current_process->it_real_expire_ms = 0;
+	current_process->it_real_interval_ms = 0;
+	if (current_process->saved_context)
+	{
+		kfree(current_process->saved_context);
+		current_process->saved_context = NULL;
+	}
+	current_process->signal_enter_pending = 0;
+	return 1;
+}
 static struct tcp_wire_outbound g_out;
 
 static inline uint64_t tcp_irq_save(void)
@@ -240,6 +266,15 @@ static void tcp_pending_clear(void)
 
 	memset(&g_pending, 0, sizeof(g_pending));
 	tcp_irq_restore(f);
+}
+
+void tcp_wire_on_process_exit(uint32_t pid)
+{
+	if (!g_tcp_connect_busy || g_tcp_connect_owner != pid)
+		return;
+	tcp_pending_clear();
+	g_tcp_connect_owner = 0;
+	__sync_lock_release(&g_tcp_connect_busy);
 }
 
 static void tcp_pending_set(ip4_addr_t peer_ip, uint16_t peer_port,
@@ -1182,19 +1217,59 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 	uint16_t lport;
 	uint64_t deadline;
 	int ret;
+	uint64_t wait_deadline;
+	uint32_t my_pid;
 
 	if (!local_port_out || !seq_out || !ack_out || peer_port == 0)
 		return -EINVAL;
 
-	ret = tcp_wire_connect_start(peer_ip, peer_port, &lport);
-	if (ret < 0)
-		return ret;
-	*local_port_out = lport;
+	my_pid = current_process ? (uint32_t)current_process->task.pid : 0;
 
 	/*
-	 * Yieldable wait so BusyBox nc -w / wget -T (alarm/SIGALRM) can
-	 * interrupt connect. Busy-spin left SIGALRM pending until return.
+	 * Defer catchable delivery for the whole connect (including lock wait).
+	 * Otherwise SIGALRM while waiting on g_tcp_connect_busy arms BusyBox
+	 * die-from-handler → SEGV on repeat.
 	 */
+	if (current_process)
+		current_process->signal_defer_catchable = 1;
+
+	/*
+	 * One outbound association at a time. Concurrent connect (stress
+	 * parallel wget) used to overwrite g_pending → -EINVAL.
+	 * Owner pid + tcp_wire_on_process_exit: SEGV mid-connect must not
+	 * leave the lock wedged for later nc/wget.
+	 */
+	wait_deadline = clock_get_uptime_milliseconds() + TCP_WIRE_TIMEOUT_MS;
+	while (__sync_lock_test_and_set(&g_tcp_connect_busy, 1))
+	{
+		if (tcp_consume_connect_sigalrm())
+		{
+			if (current_process)
+				current_process->signal_defer_catchable = 0;
+			return -ETIMEDOUT;
+		}
+		if (clock_get_uptime_milliseconds() >= wait_deadline)
+		{
+			if (current_process)
+				current_process->signal_defer_catchable = 0;
+			return -ETIMEDOUT;
+		}
+		(void)ir0_clock_wait_block_until(
+			clock_get_uptime_milliseconds() + TCP_WIRE_POLL_MS);
+	}
+	g_tcp_connect_owner = my_pid;
+
+	ret = tcp_wire_connect_start(peer_ip, peer_port, &lport);
+	if (ret < 0)
+	{
+		g_tcp_connect_owner = 0;
+		__sync_lock_release(&g_tcp_connect_busy);
+		if (current_process)
+			current_process->signal_defer_catchable = 0;
+		return ret;
+	}
+	*local_port_out = lport;
+
 	deadline = clock_get_uptime_milliseconds() + TCP_WIRE_TIMEOUT_MS;
 	for (;;)
 	{
@@ -1204,32 +1279,43 @@ int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
 		ret = tcp_wire_connect_poll(peer_ip, peer_port, lport, seq_out,
 					    ack_out);
 		if (ret != -EAGAIN)
+		{
+			if (current_process)
+				current_process->signal_defer_catchable = 0;
+			g_tcp_connect_owner = 0;
+			__sync_lock_release(&g_tcp_connect_busy);
 			return ret;
+		}
 
 		now = clock_get_uptime_milliseconds();
 		if (now >= deadline)
 		{
 			tcp_pending_clear();
+			if (current_process)
+				current_process->signal_defer_catchable = 0;
+			g_tcp_connect_owner = 0;
+			__sync_lock_release(&g_tcp_connect_busy);
+			return -ETIMEDOUT;
+		}
+
+		if (tcp_consume_connect_sigalrm())
+		{
+			tcp_pending_clear();
+			if (current_process)
+				current_process->signal_defer_catchable = 0;
+			g_tcp_connect_owner = 0;
+			__sync_lock_release(&g_tcp_connect_busy);
 			return -ETIMEDOUT;
 		}
 
 		if (current_process &&
 		    signals_pause_should_interrupt(current_process))
 		{
+			current_process->signal_defer_catchable = 0;
 			handle_signals();
-			if (current_process->saved_context &&
-			    current_process->signal_enter_pending)
-			{
-				current_process->signal_enter_pending = 0;
-				process_restore_user_task_segments(current_process);
-				current_process->irq_frame_saved = 0;
-				current_process->coop_resched_resume = 0;
-				current_process->want_kernel_ret = 0;
-				arch_restore_user_fs_base();
-				tcp_pending_clear();
-				switch_to_user_task(&current_process->task);
-			}
 			tcp_pending_clear();
+			g_tcp_connect_owner = 0;
+			__sync_lock_release(&g_tcp_connect_busy);
 			return -EINTR;
 		}
 

--- a/net/tcp.h
+++ b/net/tcp.h
@@ -36,7 +36,7 @@ struct tcp_header
 
 int tcp_init(void);
 int tcp_wire_connect(ip4_addr_t peer_ip, uint16_t peer_port,
-		   uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out);
+		     uint16_t *local_port_out, uint32_t *seq_out, uint32_t *ack_out);
 /* Nonblocking connect: SYN sent; complete via tcp_wire_connect_poll. */
 int tcp_wire_connect_start(ip4_addr_t peer_ip, uint16_t peer_port,
 			   uint16_t *local_port_out);
@@ -44,6 +44,8 @@ int tcp_wire_connect_start(ip4_addr_t peer_ip, uint16_t peer_port,
 int tcp_wire_connect_poll(ip4_addr_t peer_ip, uint16_t peer_port,
 			  uint16_t local_port, uint32_t *seq_out,
 			  uint32_t *ack_out);
+/* Drop connect lock if @pid owned it (process_exit / SEGV mid-connect). */
+void tcp_wire_on_process_exit(uint32_t pid);
 int tcp_wire_poll_readable(ip4_addr_t peer_ip, uint16_t peer_port,
 			   uint16_t local_port);
 int tcp_wire_poll_writable(ip4_addr_t peer_ip, uint16_t peer_port,

--- a/setup/pid1/net_command_stress.c
+++ b/setup/pid1/net_command_stress.c
@@ -1,0 +1,284 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: net_command_stress.c
+ * Description: Aggressive BusyBox networking applet stress for QEMU (pid1).
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+static void tag(const char *s)
+{
+	write(1, s, strlen(s));
+}
+
+static int runv(char *const av[])
+{
+	pid_t p;
+	int st = -1;
+
+	p = fork();
+	if (p < 0)
+		return -1;
+	if (p == 0)
+	{
+		execv(av[0], av);
+		_exit(127);
+	}
+	if (waitpid(p, &st, 0) < 0)
+		return -1;
+	if (WIFSIGNALED(st))
+		return 1000 + WTERMSIG(st);
+	if (!WIFEXITED(st))
+		return -2;
+	return WEXITSTATUS(st);
+}
+
+/* Soft retry for QEMU/SLIRP + rare RX checksum flakes (not SEGV). */
+static int runv_ping(char *const av[])
+{
+	int i;
+	int rc = -1;
+
+	for (i = 0; i < 3; i++)
+	{
+		rc = runv(av);
+		if (rc == 0 || rc >= 1000)
+			return rc;
+	}
+	return rc;
+}
+
+static void note_rc(const char *name, int rc)
+{
+	char buf[96];
+	int n;
+
+	n = snprintf(buf, sizeof(buf), "STRESS_RC %s=%d\n", name, rc);
+	if (n > 0)
+		write(1, buf, (size_t)n);
+}
+
+static int force_eth0_up(void)
+{
+	struct ifreq ifr;
+	int sk;
+	int rc;
+
+	sk = socket(AF_INET, SOCK_DGRAM, 0);
+	if (sk < 0)
+		return -1;
+	memset(&ifr, 0, sizeof(ifr));
+	strncpy(ifr.ifr_name, "eth0", IFNAMSIZ);
+	rc = ioctl(sk, SIOCGIFFLAGS, &ifr);
+	if (rc == 0)
+	{
+		ifr.ifr_flags |= IFF_UP | IFF_RUNNING;
+		rc = ioctl(sk, SIOCSIFFLAGS, &ifr);
+	}
+	close(sk);
+	return rc;
+}
+
+int main(void)
+{
+	int fails = 0;
+	int round;
+	int rc;
+
+	tag("NET_STRESS_START\n");
+	(void)force_eth0_up();
+
+	for (round = 1; round <= 8; round++)
+	{
+		char rtag[32];
+
+		snprintf(rtag, sizeof(rtag), "NET_STRESS_ROUND_%d\n", round);
+		tag(rtag);
+
+		/* ifconfig: display + mutate */
+		rc = runv((char *[]){"/bin/ifconfig", NULL});
+		note_rc("ifconfig", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/ifconfig", "-a", NULL});
+		note_rc("ifconfig_-a", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/ifconfig", "eth0", "10.0.2.15",
+					 "netmask", "255.255.255.0",
+					 "broadcast", "10.0.2.255", "up", NULL});
+		note_rc("ifconfig_set", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/ifconfig", "eth0", "mtu", "1500", NULL});
+		note_rc("ifconfig_mtu", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/ifconfig", "eth0", "txqueuelen",
+					 "1000", NULL});
+		note_rc("ifconfig_txq", rc);
+		if (rc >= 1000)
+			fails++;
+
+		/* route */
+		rc = runv((char *[]){"/bin/route", "add", "default", "gw",
+					 "10.0.2.2", NULL});
+		note_rc("route_add", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/route", "-n", NULL});
+		note_rc("route_n", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/route", "del", "default", NULL});
+		note_rc("route_del", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/route", "add", "default", "gw",
+					 "10.0.2.2", NULL});
+		note_rc("route_add2", rc);
+		if (rc >= 1000)
+			fails++;
+
+		/* ping: many fancy flags — must get replies (RX health gate) */
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "1", "-W", "2",
+					 "10.0.2.2", NULL});
+		note_rc("ping", rc);
+		if (rc != 0)
+			fails++;
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "1", "-W", "2", "-I",
+					 "eth0", "10.0.2.2", NULL});
+		note_rc("ping_I_dev", rc);
+		if (rc != 0)
+			fails++;
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "1", "-W", "2", "-I",
+					 "10.0.2.15", "10.0.2.2", NULL});
+		note_rc("ping_I_ip", rc);
+		if (rc != 0)
+			fails++;
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "1", "-W", "2", "-t",
+					 "16", "10.0.2.2", NULL});
+		note_rc("ping_t", rc);
+		if (rc != 0)
+			fails++;
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "2", "-A", "-W", "2",
+					 "-q", "-s", "32", "10.0.2.2", NULL});
+		note_rc("ping_Aqs", rc);
+		if (rc != 0)
+			fails++;
+		rc = runv_ping((char *[]){"/bin/ping", "-c", "1", "-W", "2", "-p",
+					 "aa", "10.0.2.2", NULL});
+		note_rc("ping_p", rc);
+		if (rc != 0)
+			fails++;
+
+		/* netstat / nslookup */
+		rc = runv((char *[]){"/bin/netstat", NULL});
+		note_rc("netstat", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/netstat", "-rn", NULL});
+		note_rc("netstat_rn", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/nslookup", "10.0.2.2", "10.0.2.3",
+					 NULL});
+		note_rc("nslookup", rc);
+		if (rc >= 1000)
+			fails++;
+
+		/* nc timeout exit(1) is expected (port 9 discard). */
+		rc = runv((char *[]){"/bin/nc", "-w", "2", "10.0.2.2", "9",
+					 NULL});
+		note_rc("nc_w", rc);
+		if (rc >= 1000)
+			fails++;
+		/* wget: only SEGV/crash counts; host HTTP may be flaky */
+		rc = runv((char *[]){"/bin/wget", "-q", "-O", "-",
+					 "http://10.0.2.2/", NULL});
+		note_rc("wget", rc);
+		if (rc >= 1000)
+			fails++;
+		rc = runv((char *[]){"/bin/wget", "-q", "-O", "/tmp/w.out",
+					 "http://10.0.2.2/", NULL});
+		note_rc("wget_O_file", rc);
+		if (rc >= 1000)
+			fails++;
+
+		/* hostname (enabled in ir0_full) */
+		rc = runv((char *[]){"/bin/hostname", NULL});
+		note_rc("hostname", rc);
+		if (rc >= 1000)
+			fails++;
+
+		/* Concurrent pings only — wire TCP is single g_out (parallel wget SEGVs). */
+		{
+			pid_t kids[2];
+			int i;
+
+			for (i = 0; i < 2; i++)
+			{
+				kids[i] = fork();
+				if (kids[i] == 0)
+				{
+					execl("/bin/ping", "ping", "-c", "1",
+					      "-W", "2", "10.0.2.2", (char *)0);
+					_exit(127);
+				}
+			}
+			for (i = 0; i < 2; i++)
+			{
+				if (kids[i] > 0)
+				{
+					int cst = 0;
+
+					waitpid(kids[i], &cst, 0);
+					if (WIFSIGNALED(cst))
+						fails++;
+				}
+			}
+			tag("NET_STRESS_PARALLEL_DONE\n");
+		}
+	}
+
+	/* Abuse ioctl control path (musl if_nametoindex style) */
+	for (round = 0; round < 64; round++)
+	{
+		struct ifreq ifr;
+		int sk = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+
+		if (sk < 0)
+		{
+			fails++;
+			break;
+		}
+		memset(&ifr, 0, sizeof(ifr));
+		strncpy(ifr.ifr_name, "eth0", IFNAMSIZ);
+		if (ioctl(sk, SIOCGIFINDEX, &ifr) != 0)
+			fails++;
+		close(sk);
+	}
+	tag("NET_STRESS_IFINDEX_DONE\n");
+
+	if (fails == 0)
+		tag("NET_STRESS_PASS\n");
+	else
+		tag("NET_STRESS_FAIL\n");
+	tag("NET_STRESS_ALL_DONE\n");
+	_exit(fails ? 1 : 0);
+}


### PR DESCRIPTION
## Summary
- Last pre-release before final `v0.0.1`: version string `0.0.1-rc4`, annotated tag `v0.0.1-rc4` (already pushed).
- Networking/stress stabilization for ISD BusyBox (`NET_STRESS_PASS` / `NC_ONLY_PASS`).
- Post-rc4 policy: bugfixing and stabilization only until ship.

## Docs
- `Documentation/releases/IR0_0.0.1_RC4.md`
- `NETWORKING_MATRIX.md`, `STABLE.md`, `CHANGELOG.md`

## Test plan
- [x] `NET_STRESS_PASS`, `NC_ONLY_PASS`
- [x] `arch-guard`, `build-matrix-min`, `tests/host` 43/43
- [ ] Merge to `master` (branch protection)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RTL8139 RX, signal delivery during blocking connect, and shared TCP wire state—security-sensitive networking paths—but scope is stabilization with documented single-outbound-TCP limits and stress smokes as evidence.
> 
> **Overview**
> Cuts **`v0.0.1-rc4`** as the last pre-release before final `v0.0.1`: version string in `version.h` / README, plus policy that post-rc4 work is **bugfix and stabilization only** (documented in RC4, STABLE, SCOPE, ROADMAP, BACKLOG).
> 
> **Kernel networking (ISD BusyBox `ir0_full` under QEMU user-net):** adds mutating **`SIOCSIF*`** and **`SIOCADDRT` / `SIOCDELRT`**, Linux-aligned **`IFF_*`**, and richer **`/proc/net/dev`** for fancy `ifconfig`. ICMP gains **`IP_TTL`**, **`SO_BINDTODEVICE`**, and **`IP_MULTICAST_IF`**; **`AF_UNIX SOCK_DGRAM`** sockets back musl `if_nametoindex` ioctls. TCP wire **connect** is interruptible: **`signal_defer_catchable`** defers user handlers during connect, lone **SIGALRM** maps to **`-ETIMEDOUT`** (fixes repeat `nc -w` SEGVs), a single outbound connect lock with **`tcp_wire_on_process_exit`** on crash/exit.
> 
> **RTL8139:** corrects MSR link polarity, reads RX write pointer from **CBR (0x3A)** instead of the ring buffer, and drains on **RxOverflow** so RX does not wedge after stress.
> 
> Adds **`setup/pid1/net_command_stress.c`** and expands **`NETWORKING_MATRIX.md`** / **`IR0_0.0.1_RC4.md`** with `NET_STRESS_PASS` / `NC_ONLY_PASS` reproduction steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fda802bda2913ee8eb9fe90b16a7da04e513fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->