### PR TITLE
fix(mm): split 2MiB identity PDEs, demand-zero anon mmap, arena guards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1111,9 +1111,13 @@ kernel-x64.iso: kernel-x64.bin arch/x86-64/grub.cfg
 	@echo "✓ ISO created: $@"
 
 # Kernel con tests in-kernel (solo al hacer make tests / kernel-tests)
-# config.h documents IR0_KERNEL_TESTS; Makefile ensures it for this target
+# config.h documents IR0_KERNEL_TESTS; Makefile ensures it for this target.
+# kmain must be compiled with that flag: a leftover kernel-x64.bin main.o
+# would skip kernel_test_run_all() and make kernel-tests time out.
 kernel-x64-test.bin: CFLAGS += -DIR0_KERNEL_TESTS=1
 kernel-x64-test.bin: $(ALL_OBJS_TEST) arch/x86-64/linker.ld
+	@rm -f kernel/main.o
+	@$(MAKE) --no-print-directory CFLAGS="$(CFLAGS)" kernel/main.o
 	@echo "  LD      $@ (with in-kernel tests)"
 	@$(LD) $(LDFLAGS) -o $@ $(ALL_OBJS_TEST)
 	@echo "✓ Kernel (test) linked: $@"

--- a/kernel/syscalls/mm_syscalls.c
+++ b/kernel/syscalls/mm_syscalls.c
@@ -28,6 +28,7 @@
 #include <ir0/mm_struct.h>
 #include <ir0/paging.h>
 #include <ir0/pmm.h>
+#include <mm/allocator.h>
 #include <ir0/arch_port.h>
 #include <ir0/ktm/checkpoint.h>
 #include <stdbool.h>
@@ -953,6 +954,14 @@ void *sys_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t off
                             process_pgd(current_process));
       return ret;
     }
+    if (hint_addr < (uintptr_t)PMM_PHYS_BASE &&
+	hint_addr + length > (uintptr_t)SIMPLE_HEAP_START)
+    {
+      ret = SYSCALL_PTR_ERR(EINVAL);
+      mmap_audit_log_return("map-fixed-kernel-heap", ret, hint_addr, length, 0,
+			    process_pgd(current_process));
+      return ret;
+    }
 
     mm_prepare_map_fixed(hint_addr, length);
     virt_addr = hint_addr;
@@ -996,6 +1005,18 @@ void *sys_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t off
                                         length);
     if (virt_addr == 0)
       return SYSCALL_PTR_ERR(ENOMEM);
+  }
+
+  if ((flags & MAP_FIXED) == 0 &&
+      (virt_addr < USER_MMAP_START ||
+       virt_addr + aligned_len > USER_MMAP_END ||
+       virt_addr + aligned_len < virt_addr))
+  {
+    klog_notice_fmt("MMAP",
+		    "reject va=%llx len=%llx outside mmap arena\n",
+		    (unsigned long long)virt_addr,
+		    (unsigned long long)aligned_len);
+    return SYSCALL_PTR_ERR(ENOMEM);
   }
 
   /* Determine page flags from protection flags */

--- a/kernel/test/test_brk_post_exec.c
+++ b/kernel/test/test_brk_post_exec.c
@@ -21,6 +21,7 @@
 
 #define KTEST_BUSYBOX_INITIAL_BRK 0x453000UL
 #define KTEST_BRK_GROW 0x2000UL
+#define KTEST_BRK_ACROSS_6M 0x601000UL
 
 static int ktest_pte_present(uintptr_t va)
 {
@@ -30,6 +31,18 @@ static int ktest_pte_present(uintptr_t va)
 		return 0;
 	return is_page_mapped_in_directory(process_pgd(current_process), va,
 					   &flags) == 1;
+}
+
+static int ktest_pte_user(uintptr_t va)
+{
+	uint64_t flags = 0;
+
+	if (!current_process || !process_pgd(current_process))
+		return 0;
+	if (is_page_mapped_in_directory(process_pgd(current_process), va,
+					&flags) != 1)
+		return 0;
+	return (flags & PAGE_USER) != 0;
 }
 
 void ktest_brk_post_exec(void)
@@ -54,6 +67,12 @@ void ktest_brk_post_exec(void)
 	KASSERT_EQ((uint64_t)grown, KTEST_BUSYBOX_INITIAL_BRK + KTEST_BRK_GROW);
 	KASSERT(ktest_pte_present(KTEST_BUSYBOX_INITIAL_BRK));
 	KASSERT(ktest_pte_present(KTEST_BUSYBOX_INITIAL_BRK + 0x1000UL));
+
+	/* Cross the 6 MiB supervisor-2MB identity seam (Linux split_huge_pmd). */
+	grown = sys_brk((void *)KTEST_BRK_ACROSS_6M);
+	KASSERT_EQ((uint64_t)grown, KTEST_BRK_ACROSS_6M);
+	KASSERT(ktest_pte_present(0x600000UL));
+	KASSERT(ktest_pte_user(0x600000UL));
 
 	process_set_heap_start(current_process, saved_start);
 	process_set_heap_end(current_process, saved_end);

--- a/kernel/test/test_mmap_null_placement.c
+++ b/kernel/test/test_mmap_null_placement.c
@@ -115,6 +115,41 @@ void ktest_mmap_null_placement(void)
 	slot[3] = fixed;
 	addrs[3] = fixed_addr;
 
+	{
+		uint64_t id_flags = 0;
+		void *split;
+		void *heap_fixed;
+		void *anon;
+
+		KASSERT(is_page_mapped_in_directory(process_pgd(current_process),
+						    0x800000UL, &id_flags) == 1);
+		KASSERT((id_flags & PAGE_USER) == 0);
+
+		split = ktest_mmap_anon(0x1000, KTEST_PROT_RW,
+					KTEST_MAP_PRIVATE | KTEST_MAP_ANONYMOUS |
+						KTEST_MAP_FIXED,
+					(void *)0x600000UL);
+		KASSERT(split == (void *)0x600000UL);
+		KASSERT(ktest_pte_present(0x600000UL));
+		KASSERT(sys_munmap(split, 0x1000) == 0);
+
+		heap_fixed = ktest_mmap_anon(0x1000, KTEST_PROT_RW,
+					     KTEST_MAP_PRIVATE | KTEST_MAP_ANONYMOUS |
+						     KTEST_MAP_FIXED,
+					     (void *)0x800000UL);
+		KASSERT((intptr_t)heap_fixed < 0);
+
+		anon = ktest_mmap_anon(0x4000, KTEST_PROT_RW,
+				       KTEST_MAP_PRIVATE | KTEST_MAP_ANONYMOUS,
+				       NULL);
+		KASSERT(anon != (void *)(intptr_t)-1);
+		KASSERT((uintptr_t)anon >= USER_MMAP_START);
+		KASSERT((uintptr_t)anon >= IR0_MMAP_NULL_MIN_VA);
+		((volatile char *)anon)[0] = 0x5A;
+		((volatile char *)anon)[0x3FFF] = 0x5A;
+		KASSERT(sys_munmap(anon, 0x4000) == 0);
+	}
+
 	ktest_unmap_all(slot, 4);
 
 	process_set_heap_start(current_process, saved_heap_start);

--- a/kernel/test/test_mmap_null_placement.c
+++ b/kernel/test/test_mmap_null_placement.c
@@ -145,8 +145,8 @@ void ktest_mmap_null_placement(void)
 		KASSERT(anon != (void *)(intptr_t)-1);
 		KASSERT((uintptr_t)anon >= USER_MMAP_START);
 		KASSERT((uintptr_t)anon >= IR0_MMAP_NULL_MIN_VA);
-		((volatile char *)anon)[0] = 0x5A;
-		((volatile char *)anon)[0x3FFF] = 0x5A;
+		KASSERT(ktest_pte_present((uintptr_t)anon));
+		KASSERT(ktest_pte_present((uintptr_t)anon + 0x3000UL));
 		KASSERT(sys_munmap(anon, 0x4000) == 0);
 	}
 

--- a/kernel/test/test_signal_segv_deliver.c
+++ b/kernel/test/test_signal_segv_deliver.c
@@ -13,6 +13,7 @@
 /* SPDX-License-Identifier: GPL-3.0-only */
 
 #include "test/ktest_harness.h"
+#include <config.h>
 #include <ir0/signals.h>
 #include <ir0/arch_signal.h>
 #include <ir0/process.h>

--- a/mm/page_fault.c
+++ b/mm/page_fault.c
@@ -7,7 +7,7 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: page_fault.c
- * Description: Portable page fault policy (demand paging, COW, SIGSEGV).
+ * Description: Portable page fault policy (demand paging, anon mmap, COW, SIGSEGV).
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -26,6 +26,7 @@
 #include <ir0/copy_user.h>
 #include <ir0/ktm/klog.h>
 #include <ir0/arch_page_fault.h>
+#include <ir0/abi/mmap_contract.h>
 #include <ktm.h>
 #include <ktm_probe_diag.h>
 #include <d1_13_malloc_pf_diag.h>
@@ -69,6 +70,39 @@ static struct mmap_region *pf_mmap_region_for(process_t *p, uint64_t fa)
 			return r;
 	}
 	return NULL;
+}
+
+static void pf_user_segv(process_t *p, uint64_t *stack, uint64_t fault_addr,
+			 const struct arch_page_fault_info *info);
+
+/*
+ * Linux do_anonymous_page: demand-zero a 4 KiB user leaf.
+ * Heap, stack, and anonymous mmap VMAs share this path.
+ */
+static void pf_demand_zero_page(process_t *current, uint64_t fault_addr,
+				uint64_t map_flags, uint64_t *stack,
+				const struct arch_page_fault_info *info)
+{
+	uintptr_t phys_addr;
+	uint64_t vaddr_aligned;
+
+	phys_addr = pmm_alloc_frame();
+	if (phys_addr == 0)
+	{
+		pf_user_segv(current, stack, fault_addr, info);
+		return;
+	}
+
+	vaddr_aligned = fault_addr & ~0xFFFUL;
+	if (map_page_in_directory(process_pgd(current), vaddr_aligned,
+				  phys_addr, map_flags) != 0)
+	{
+		pmm_free_frame(phys_addr);
+		pf_user_segv(current, stack, fault_addr, info);
+		return;
+	}
+
+	memset((void *)(uintptr_t)phys_addr, 0, 0x1000);
 }
 
 #if DEBUG_D1_DIAG
@@ -388,10 +422,44 @@ void mm_page_fault_handle(const struct arch_page_fault_info *info, void *irq_fra
 		if (!current || !process_pgd(current))
 			return;
 
-		if (pf_mmap_region_for(current, fault_addr) != NULL)
 		{
-			pf_user_segv(current, stack, fault_addr, info);
-			return;
+			struct mmap_region *mr;
+
+			mr = pf_mmap_region_for(current, fault_addr);
+			if (mr != NULL)
+			{
+				if ((mr->flags & IR0_MAP_ANONYMOUS) == 0)
+				{
+					pf_user_segv(current, stack, fault_addr, info);
+					return;
+				}
+				if (mr->prot == 0)
+				{
+					pf_user_segv(current, stack, fault_addr, info);
+					return;
+				}
+				if (write && (mr->prot & 0x2) == 0) /* PROT_WRITE */
+				{
+					pf_user_segv(current, stack, fault_addr, info);
+					return;
+				}
+				if (insn_fetch && (mr->prot & 0x4) == 0) /* PROT_EXEC */
+				{
+					pf_user_segv(current, stack, fault_addr, info);
+					return;
+				}
+				{
+					uint64_t map_flags = PAGE_USER;
+
+					if (mr->prot & 0x2) /* PROT_WRITE */
+						map_flags |= PAGE_RW;
+					if (mr->prot & 0x4) /* PROT_EXEC */
+						map_flags |= PAGE_EXEC;
+					pf_demand_zero_page(current, fault_addr, map_flags,
+							    stack, info);
+				}
+				return;
+			}
 		}
 
 		if (!pf_addr_in_heap(current, fault_addr) &&
@@ -402,30 +470,11 @@ void mm_page_fault_handle(const struct arch_page_fault_info *info, void *irq_fra
 		}
 
 		{
-			uintptr_t phys_addr = pmm_alloc_frame();
-
-			if (phys_addr == 0)
-			{
-				pf_user_segv(current, stack, fault_addr, info);
-				return;
-			}
-
-			uint64_t flags = PAGE_USER | PAGE_RW;
+			uint64_t map_flags = PAGE_USER | PAGE_RW;
 
 			if (insn_fetch)
-				flags |= PAGE_EXEC;
-
-			uint64_t vaddr_aligned = fault_addr & ~0xFFF;
-
-			if (map_page_in_directory(process_pgd(current), vaddr_aligned,
-						  phys_addr, flags) != 0)
-			{
-				pmm_free_frame(phys_addr);
-				pf_user_segv(current, stack, fault_addr, info);
-				return;
-			}
-
-			memset((void *)(uintptr_t)phys_addr, 0, 0x1000);
+				map_flags |= PAGE_EXEC;
+			pf_demand_zero_page(current, fault_addr, map_flags, stack, info);
 		}
 		return;
 	}

--- a/mm/paging.c
+++ b/mm/paging.c
@@ -7,7 +7,7 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: paging.c
- * Description: IR0 kernel source/header file
+ * Description: Page tables, 2 MiB identity split, and leaf install.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -28,6 +28,7 @@
 #include <ir0/validation.h>
 #include <ir0/ahci_api.h>
 #include <ir0/arch_port.h>
+#include <ir0/arch_cpu.h>
 
 static uint32_t fase40_copy_diag_events;
 
@@ -327,19 +328,32 @@ int is_page_mapped_in_directory(uint64_t *pml4, uint64_t virt_addr, uint64_t *fl
 	if (!mm_pte_present(pml4[idx[0]]))
 		return 0;
 	if (paging_entry_large(pml4[idx[0]]))
-		return 0;
+	{
+		if (flags_out)
+			*flags_out = pml4[idx[0]] & 0xFFFu;
+		return 1;
+	}
 
 	pdpt = paging_entry_table(pml4[idx[0]]);
 	if (!pdpt || !mm_pte_present(pdpt[idx[1]]))
 		return 0;
 	if (paging_entry_large(pdpt[idx[1]]))
-		return 0;
+	{
+		if (flags_out)
+			*flags_out = pdpt[idx[1]] & 0xFFFu;
+		return 1;
+	}
 
 	pd = paging_entry_table(pdpt[idx[1]]);
 	if (!pd || !mm_pte_present(pd[idx[2]]))
 		return 0;
 	if (paging_entry_large(pd[idx[2]]))
-		return 0;
+	{
+		/* Linux pmd_present && pmd_large: a 2 MiB leaf is mapped. */
+		if (flags_out)
+			*flags_out = pd[idx[2]] & 0xFFFu;
+		return 1;
+	}
 
 	pt = paging_entry_table(pd[idx[2]]);
 	if (!pt || !mm_pte_present(pt[idx[3]]))
@@ -572,6 +586,46 @@ static uint64_t alloc_page_table(int level)
     return (uint64_t)page;
 }
 
+/*
+ * Linux split_huge_pmd: replace a PD-level 2 MiB leaf with 512×4 KiB
+ * supervisor leaves so a later 4 KiB USER PTE can be installed.
+ */
+static int paging_split_large_pde(uint64_t *pd, size_t index)
+{
+	uint64_t pde;
+	uint64_t phys_base;
+	uint64_t pt_phys;
+	uint64_t *pt;
+	uint64_t leaf_flags;
+	int exec;
+	size_t i;
+
+	if (!pd)
+		return -1;
+	pde = pd[index];
+	if (!mm_pte_present(pde) || !paging_entry_large(pde))
+		return -1;
+
+	pt_phys = alloc_page_table(3);
+	if (pt_phys == 0)
+		return -1;
+	pt = (uint64_t *)(uintptr_t)pt_phys;
+	phys_base = paging_entry_pfn(pde);
+	leaf_flags = PAGE_RW;
+	if (pde & PAGE_NX)
+		exec = 0;
+	else
+		exec = 1;
+
+	for (i = 0; i < 512; i++)
+		pt[i] = mm_make_leaf_pte(phys_base + (i * PAGE_SIZE_4KB),
+					 leaf_flags, exec);
+
+	pd[index] = mm_make_table_pte((uintptr_t)pt_phys, 0);
+	tlb_invalidate_all();
+	return 0;
+}
+
 /**
  * Get or create a page table at the specified level
  * @pml4: PML4 table address
@@ -604,7 +658,12 @@ static uint64_t *get_or_create_table(uint64_t *parent, size_t index, int create,
 	}
 
 	if (paging_entry_large(parent[index]))
-		return NULL;
+	{
+		if (!create || level != 3)
+			return NULL;
+		if (paging_split_large_pde(parent, index) != 0)
+			return NULL;
+	}
 
 	/*
 	 * Propagate PAGE_USER onto existing table levels (e.g. supervisor identity
@@ -632,6 +691,15 @@ int map_page_in_directory(uint64_t *pml4, uint64_t virt_addr, uint64_t phys_addr
 	uint64_t *pt;
 
 	if (!pml4)
+		return -1;
+
+	/*
+	 * Kernel heap is identity-mapped under process CR3 (kmalloc + COW
+	 * memcpy use PA as VA). PAGE_USER there hides the allocator.
+	 */
+	if ((flags & PAGE_USER) &&
+	    virt_addr >= (uint64_t)SIMPLE_HEAP_START &&
+	    virt_addr < (uint64_t)PMM_PHYS_BASE)
 		return -1;
 
 	mm_va_indices((uintptr_t)virt_addr, idx);

--- a/mm/paging.h
+++ b/mm/paging.h
@@ -107,7 +107,7 @@ int map_page_in_directory(uint64_t *pml4, uint64_t virt_addr, uint64_t phys_addr
  * @pml4: PML4 table address (page directory)
  * @virt_addr: Virtual address to check
  * @flags_out: Optional output for page flags (can be NULL)
- * Returns: 1 if mapped, 0 if not mapped, -1 on error
+ * Returns: 1 if mapped (including 2 MiB/1 GiB leaves), 0 if not mapped, -1 on error
  */
 int is_page_mapped_in_directory(uint64_t *pml4, uint64_t virt_addr, uint64_t *flags_out);
 

--- a/tests/ktm/userdev/ktm_cow_touch_case.c
+++ b/tests/ktm/userdev/ktm_cow_touch_case.c
@@ -3,13 +3,15 @@
  * Copyright (C) 2026  Iván Rodriguez
  *
  * File: ktm_cow_touch_case.c
- * Description: PID1 — fork + child write shared page (COW touch MVP).
+ * Description: PID1 — fork + child write shared page (COW touch MVP);
+ *              MAP_FIXED across 6 MiB identity seam + anonymous mmap touch.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
 
 #include <stdint.h>
 #include <string.h>
+#include <sys/mman.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -95,6 +97,44 @@ int main(void)
 	(void)ktm_assert_true(fd, "parent_page_intact", g_cow_page[0] == 'A');
 	if (g_cow_page[0] != 'A')
 		fails++;
+
+	/*
+	 * Split-proof: MAP_FIXED into the 6 MiB supervisor-2MB identity slot
+	 * (ISD ELF/brk window). Anonymous mmap stays in the high arena.
+	 */
+	{
+		int mmap6_ok = 0;
+		int mmap_ok = 0;
+		char *mmap6;
+		char *mmap_p;
+
+		mmap6 = mmap((void *)0x600000UL, 4096, PROT_READ | PROT_WRITE,
+			     MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0);
+		if (mmap6 != MAP_FAILED)
+		{
+			mmap6[0] = 0x5A;
+			mmap6[4095] = 0x5A;
+			mmap6_ok = (mmap6[0] == 0x5A && mmap6[4095] == 0x5A);
+			(void)munmap(mmap6, 4096);
+		}
+		(void)ktm_assert_true(fd, "mmap_fixed_6m_split", mmap6_ok);
+		if (!mmap6_ok)
+			fails++;
+
+		mmap_p = mmap(NULL, 16 * 1024, PROT_READ | PROT_WRITE,
+			      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (mmap_p != MAP_FAILED)
+		{
+			mmap_p[0] = 0x5A;
+			mmap_p[16 * 1024 - 1] = 0x5A;
+			mmap_ok = (mmap_p[0] == 0x5A &&
+				   mmap_p[16 * 1024 - 1] == 0x5A);
+			(void)munmap(mmap_p, 16 * 1024);
+		}
+		(void)ktm_assert_true(fd, "mmap_anon_touch", mmap_ok);
+		if (!mmap_ok)
+			fails++;
+	}
 
 	if (ktm_run_invariants(fd, KTM_INV_PROCESS | KTM_INV_FRAMES) != 0)
 		fails++;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué se repara

Los SIGSEGV de ISD al tocar heap/mmap no eran del producto userspace: el kernel trataba mal las hojas 2 MiB de identity map y el #PF de mmap anónimo.

1. **2 MiB supervisor identity vs ELF/brk 4 KiB USER**  
   CR3 de proceso identity-mapea `[0x600000, 512 MiB)` como PDE PS. `get_or_create_table()` devolvía NULL ante una hoja grande, así que `map_page` USER en el seam de 6 MiB fallaba y el write iba a páginas supervisor.

2. **`mmap(NULL)` en identity (~129 MiB, `addr=809cxxxx`)**  
   `is_page_mapped_in_directory()` trataba hojas PS como *unmapped*. El colocador creía libre el identity de PMM.

3. **#PF en VMA mmap anónimo**  
   Un not-present dentro de un mmap anónimo iba siempre a SIGSEGV en vez de demand-zero (Linux `do_anonymous_page`).

## Qué no es este PR

- No recorta applets, pipes ni RAM del harness.
- No cambia el ABI `sys_brk` vs musl.
- No toca `kernel/process/exit.c`.

## Cambios

| Sitio | Analogía Linux | Qué hace |
|---|---|---|
| `paging_split_large_pde()` | `split_huge_pmd` | PDE 2 MiB → 512×4 KiB supervisor + `tlb_invalidate_all()` |
| `get_or_create_table()` | idem | Con `create` y PD, split en vez de NULL |
| `map_page_in_directory()` | no USER sobre kernel heap | Rechaza `PAGE_USER` en `[SIMPLE_HEAP_START, PMM_PHYS_BASE)` |
| `is_page_mapped_in_directory()` | `pmd_large` sigue mapped | Hojas 2 MiB/1 GiB cuentan como ocupadas |
| `page_fault.c` | `do_anonymous_page` | Demand-zero en mmap anónimo (PROT_NONE / file / prot violation siguen SEGV) |
| `sys_mmap` | arena user | `MAP_FIXED` sobre kernel heap → `-EINVAL`; VA fuera de `[USER_MMAP_START, USER_MMAP_END)` → `-ENOMEM` |

ktest: brk que cruza 6 MiB con PTE USER; mmap MAP_FIXED split en `0x600000`; MAP_FIXED en `0x800000` rechazado; colocación de mmap anónimo en el arena (PTE via PGD; el touch ring-3 está en cow_touch).  
`make kernel-tests` recompila `kmain` con `IR0_KERNEL_TESTS` para no reutilizar el `main.o` del kernel de producto.

## Certificación

- `python3 scripts/architecture_guard.py` — OK
- `make kernel-x64.bin` — linked
- `make kernel-tests` — **All 38 test(s) passed** (`ok 35 - mmap_null_placement`, `ok 37 - brk_post_exec`)
- `make ktm-run` — `SUITE_END pass=16 fail=0`, `KTM_SUITE_OK`, `/sbin/init loaded (PID 1)`
- `make ktm-userdev-cow-run` — `mmap_fixed_6m_split`, `mmap_anon_touch`, `KTM_USERDEV_COW_OK`

Queda fuera de esta oleada: UAF `addr=0x48` tras ~80 exec desde PID 1, y el ABI `sys_brk` vs musl.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f90915-231f-4526-a224-37d78303db46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f90915-231f-4526-a224-37d78303db46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

