### PR TITLE
chore(git): commits del mantenedor solo, sin Co-authored-by

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,11 @@ Signed-off-by: Iván Ezequiel Rodriguez <ivanrwcm25@gmail.com>
 ```
 
 Tipos: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `perf`.
-Sin trailers de agente (`Co-authored-by: Cursor`, etc.).
+Sin ningún `Co-authored-by:` (ni del agente, ni del mantenedor como
+co-autor). Author y Committer: Iván Ezequiel Rodriguez
+`<ivanrwcm25@gmail.com>`. Los agentes de la nube deben usar
+`python3 scripts/ir0_git_commit.py` (o `git commit-tree`) y no publicar
+si un hook inyectó trailers.
 
 ## 5. Parche
 

--- a/Documentation/ai_driven_dev/README.md
+++ b/Documentation/ai_driven_dev/README.md
@@ -50,7 +50,7 @@ Review the diff under `Documentation/ai_driven_dev/` before committing.
 | `kernel-architecture-rigor.md` | always | Facades, SPDX, testing, honest docs |
 | `kernel-c-allman-style.md` | C sources | Allman brace style |
 | `kernel-docs-language-policy.md` | `**/*.md` | English primary; Spanish in `Documentation/esp/` |
-| `ir0-git-commit-hygiene.md` | always | Signed-off-by required; no agent Co-authored-by |
+| `ir0-git-commit-hygiene.md` | always | Maintainer author only; Signed-off-by; never Co-authored-by |
 | `ir0-roadmap-research-multiagent.md` | always | T0–T3 tiers, web research, CTR gates |
 | `ir0-development-plan-mode.md` | always | When to plan before coding |
 | `ir0-development-multiagent-format.md` | always | Parallel agents and oleada report format |

--- a/Documentation/ai_driven_dev/rules/ir0-git-commit-hygiene.md
+++ b/Documentation/ai_driven_dev/rules/ir0-git-commit-hygiene.md
@@ -1,39 +1,58 @@
 <!-- IR0 AI dev rule: ir0-git-commit-hygiene -->
 <!-- alwaysApply: true -->
-<!-- description: Git commits — Signed-off-by required; no agent Co-authored-by attribution -->
+<!-- description: Git commits — maintainer identity only; Signed-off-by; never Co-authored-by -->
 
 # Git commit hygiene
 
+This rule is **always on**, including Cursor Cloud / background agents.
+It is not optional documentation. Treat it like architecture rigor.
+
 ## Identity (mandatory)
 
-All commits created or amended by the agent **must** use the maintainer's git identity only:
+Every commit the agent creates, amends, or rewrites **must** have
+**Author** and **Committer** set to the maintainer only:
 
 - **Name:** Iván Ezequiel Rodriguez
 - **Email:** ivanrwcm25@gmail.com
 
-Always pass **`-s`** so the commit includes:
+Never publish `Author: Cursor Agent`, `cursoragent@cursor.com`, or any
+tool/bot identity. Cloud platforms that default to an agent author **must**
+be overridden (`GIT_AUTHOR_*` / `GIT_COMMITTER_*` / `git commit-tree`).
+
+Always include DCO:
 
 ```text
 Signed-off-by: Iván Ezequiel Rodriguez <ivanrwcm25@gmail.com>
 ```
 
-Use the repo's configured `user.name` / `user.email` when they match the above; never substitute agent or tool identities.
+Use `git commit -s` or `python3 scripts/ir0_git_commit.py` (preferred:
+`commit-tree`, no IDE commit hooks).
 
-## Forbidden in commit messages
+## Forbidden: Co-authored-by (anyone)
 
-**Never** add to the commit body or trailers:
+**Never** add `Co-authored-by:` to a commit message or GitHub PR.
 
-- Any `Co-authored-by:` line attributing an AI agent, IDE automation, or third-party tool
-- `Helped-by:`, `Reviewed-by:`, or similar non-maintainer attribution unless the user explicitly asks
+Forbidden in full, not only agent names:
 
-If a hook injects an agent `Co-authored-by` trailer, **do not push**. Rewrite the message (e.g. `git filter-repo` message callback, or `git commit-tree` from a plain shell **without** IDE commit hooks) before publishing.
+- `Co-authored-by: Cursor …`
+- `Co-authored-by: Cursor Agent <cursoragent@cursor.com>`
+- `Co-authored-by: Iván Ezequiel Rodriguez <…>` (maintainer is the
+  **author**, never a listed co-author of an agent commit)
+- Any other named person or tool as co-author unless the user **explicitly**
+  asks to add that person on that commit
+
+GitHub shows PR co-authors from these trailers. Cloud agents that inject
+`Author: <agent>` plus `Co-authored-by: <maintainer>` must **rewrite before
+push** (`git commit-tree` / `git filter-repo`). Do not leave that pair on
+published history.
+
+Also do not add `Helped-by:`, `Reviewed-by:`, or similar attribution unless
+the user explicitly asks.
 
 ## When creating commits
 
-Prefer **`git commit-tree`** or a plain terminal shell over IDE-integrated commit flows when hooks append agent trailers.
-
 ```bash
-git commit -s -m "$(cat <<'EOF'
+python3 scripts/ir0_git_commit.py -m "$(cat <<'EOF'
 Short subject line.
 
 Optional body in complete sentences.
@@ -41,11 +60,41 @@ EOF
 )"
 ```
 
-- **Always `-s`** on new commits and on `--amend` when the user requests amend.
+Or a plain shell with identity forced:
+
+```bash
+export GIT_AUTHOR_NAME='Iván Ezequiel Rodriguez'
+export GIT_AUTHOR_EMAIL='ivanrwcm25@gmail.com'
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
+git commit -s --author="$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>" -m "$(cat <<'EOF'
+Short subject line.
+
+Optional body in complete sentences.
+EOF
+)"
+```
+
+Then **immediately** inspect `git log -1 --format='Author: %an <%ae>%n%b'`.
+If `Co-authored-by:` or a non-maintainer author appeared, **do not push**.
+Rewrite with `scripts/ir0_git_commit.py --amend-head` or `git commit-tree`.
+
 - Plain HEREDOC title + body — no agent trailers.
 - Do not append Co-authored-by “for courtesy” or tool “best practice”.
-- If a hook rejects the commit, fix in a **new** commit per user git rules — do not amend unless the user asks and amend conditions are met.
 
 ## Pre-push check
 
-Before any push the agent initiates, scan commit messages in the range for forbidden `Co-authored-by:` agent trailers (`git log --format=%B`).
+Before any push the agent initiates:
+
+```bash
+python3 scripts/repo_hygiene_guard.py
+git log origin/master..HEAD --format='Author: %an <%ae>%n%b'
+```
+
+`repo_hygiene_guard.py` checks **this branch vs `origin/master`**. That catches
+new cloud-agent commits. Use `python3 scripts/repo_hygiene_guard.py --all-history`
+to audit commits already on master (requires an admin rewrite of protected
+`master` to erase already-merged trailers).
+
+Reject the push if any commit in the range has `Co-authored-by:` or an
+author/committer other than Iván Ezequiel Rodriguez.

--- a/scripts/ir0_git_commit.py
+++ b/scripts/ir0_git_commit.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-only
+"""
+Create or rewrite a git commit with IR0 maintainer identity only.
+
+Cloud / IDE hooks often set Author to an agent and append
+Co-authored-by: <maintainer>. This helper uses git commit-tree so those
+trailers never land on published history.
+
+Usage:
+  python3 scripts/ir0_git_commit.py -m "subject\\n\\nbody"
+  python3 scripts/ir0_git_commit.py --amend-head
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MAINTAINER_NAME = "Iván Ezequiel Rodriguez"
+MAINTAINER_EMAIL = "ivanrwcm25@gmail.com"
+SOB = f"Signed-off-by: {MAINTAINER_NAME} <{MAINTAINER_EMAIL}>"
+
+
+def run(args: list[str], *, input_text: str | None = None) -> str:
+    proc = subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        input=input_text,
+        capture_output=True,
+        check=False,
+        env=commit_env(),
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr or proc.stdout or "command failed\n")
+        raise SystemExit(proc.returncode)
+    return proc.stdout
+
+
+def commit_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["GIT_AUTHOR_NAME"] = MAINTAINER_NAME
+    env["GIT_AUTHOR_EMAIL"] = MAINTAINER_EMAIL
+    env["GIT_COMMITTER_NAME"] = MAINTAINER_NAME
+    env["GIT_COMMITTER_EMAIL"] = MAINTAINER_EMAIL
+    return env
+
+
+def sanitize_message(msg: str) -> str:
+    lines = []
+    for line in msg.replace("\r\n", "\n").split("\n"):
+        if line.lower().startswith("co-authored-by:"):
+            continue
+        if line.lower().startswith("helped-by:"):
+            continue
+        lines.append(line.rstrip())
+    while lines and lines[-1] == "":
+        lines.pop()
+    text = "\n".join(lines).rstrip() + "\n"
+    if SOB not in text:
+        text = text.rstrip() + "\n\n" + SOB + "\n"
+    return text
+
+
+def write_commit(tree: str, parents: list[str], message: str) -> str:
+    cmd = ["git", "commit-tree", tree]
+    for parent in parents:
+        cmd.extend(["-p", parent])
+    sha = run(cmd, input_text=sanitize_message(message)).strip()
+    if not sha:
+        raise SystemExit("git commit-tree produced no sha")
+    return sha
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("-m", "--message", default="", help="Commit message (subject + body)")
+    ap.add_argument(
+        "--amend-head",
+        action="store_true",
+        help="Rebuild HEAD with the same tree/parent, sanitizing identity and trailers",
+    )
+    args = ap.parse_args()
+
+    if args.amend_head:
+        tree = run(["git", "write-tree"]).strip()
+        parents = run(["git", "rev-parse", "HEAD^@"]).split()
+        message = args.message if args.message.strip() else run(
+            ["git", "log", "-1", "--format=%B", "HEAD"]
+        )
+        sha = write_commit(tree, parents, message)
+        run(["git", "reset", "--soft", sha])
+        print(sha)
+        return 0
+
+    if not args.message.strip():
+        ap.error("provide -m or --amend-head")
+
+    status = run(["git", "diff", "--cached", "--name-only"]).strip()
+    if not status:
+        print("nothing staged", file=sys.stderr)
+        return 1
+
+    tree = run(["git", "write-tree"]).strip()
+    parent = run(["git", "rev-parse", "HEAD"]).strip()
+    sha = write_commit(tree, [parent], args.message)
+    run(["git", "reset", "--soft", sha])
+    print(sha)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/make/pre-submit.mk
+++ b/scripts/make/pre-submit.mk
@@ -16,7 +16,7 @@ pre-submit:
 
 help-pre-submit:
 	@echo "IR0 pre-submit (local only — no push)"
-	@echo "  make pre-submit                 # kernel + arch-guard + tests/host + fmt"
+	@echo "  make pre-submit                 # kernel + arch-guard + hygiene + tests/host + fmt"
 	@echo "  make pre-submit SUBSYSTEM=mm    # + smoke-mm-cow-lazy"
 	@echo "  make pre-submit SUBSYSTEM=net   # + smoke-stream-sock"
 	@echo "  make pre-submit SUBSYSTEM=arm64 # + smoke-arm64"

--- a/scripts/pre_submit.sh
+++ b/scripts/pre_submit.sh
@@ -101,6 +101,14 @@ else
 	SMOKES_PASSED=$((SMOKES_PASSED + 1))
 fi
 
+if ! make -s repo-hygiene-guard; then
+	echo "  repo-hygiene-guard: FAIL"
+	FAIL=1
+else
+	echo "  repo-hygiene-guard: OK"
+	SMOKES_PASSED=$((SMOKES_PASSED + 1))
+fi
+
 run_host_tests || true
 check_fmt || true
 

--- a/scripts/repo_hygiene_guard.py
+++ b/scripts/repo_hygiene_guard.py
@@ -5,7 +5,7 @@ IR0 repository hygiene guardrails.
 Checks:
 1) No obviously unnecessary artifacts are tracked.
 2) No compiled binaries or build outputs under setup/pid1 or vendored BusyBox.
-3) No forbidden agent Co-authored-by trailers in branch history.
+3) No Co-authored-by trailers and no agent Author/Committer in history.
 4) Spanish markdown naming/location is constrained to /esp directories.
 """
 
@@ -15,9 +15,14 @@ import re
 import subprocess
 import sys
 
-FORBIDDEN_AGENT_COAUTHOR_RE = re.compile(
-    r"^Co-authored-by:.*<cursoragent@",
+FORBIDDEN_COAUTHOR_RE = re.compile(
+    r"^Co-authored-by:",
     re.IGNORECASE | re.MULTILINE,
+)
+
+AGENT_IDENTITY_RE = re.compile(
+    r"cursoragent@|^\s*Cursor Agent\s*$",
+    re.IGNORECASE,
 )
 
 
@@ -151,9 +156,31 @@ def is_spanish_named_markdown(path: str) -> bool:
     return stem.endswith("_es") or stem.endswith("-es") or stem.startswith("esp_")
 
 
-def git_head_commits():
+def git_commits_to_scan():
+    """
+    Scan commits this branch introduces relative to origin/master.
+
+    Already-merged history cannot be rewritten through a PR when master is
+    protected. New agent commits still fail. Use --all-history to audit the
+    whole reachable graph (e.g. after an admin rewrite of master).
+    """
+    extra = sys.argv[1:] if len(sys.argv) > 1 else []
+    if "--all-history" in extra:
+        spec = ["HEAD"]
+    else:
+        upstream = subprocess.run(
+            ["git", "rev-parse", "--verify", "origin/master"],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if upstream.returncode == 0:
+            spec = ["origin/master..HEAD"]
+        else:
+            spec = ["HEAD"]
     proc = subprocess.run(
-        ["git", "log", "HEAD", "--format=%H"],
+        ["git", "log", *spec, "--format=%H"],
         cwd=ROOT,
         text=True,
         capture_output=True,
@@ -164,28 +191,41 @@ def git_head_commits():
     return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
 
 
-def commits_with_forbidden_agent_coauthor():
+def commit_oneline(commit: str) -> str:
+    oneline = subprocess.run(
+        ["git", "log", "-1", "--oneline", commit],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return oneline.stdout.strip() if oneline.returncode == 0 else commit
+
+
+def commits_with_forbidden_attribution():
+    """Any Co-authored-by, or Author/Committer using a cloud-agent identity."""
     bad = []
-    for commit in git_head_commits():
-        proc = subprocess.run(
-            ["git", "log", "-1", "--format=%B", commit],
+    for commit in git_commits_to_scan():
+        ident = subprocess.run(
+            ["git", "log", "-1", "--format=%an <%ae>%n%cn <%ce>%n%B", commit],
             cwd=ROOT,
             text=True,
             capture_output=True,
             check=False,
         )
-        if proc.returncode != 0:
+        if ident.returncode != 0:
             continue
-        if FORBIDDEN_AGENT_COAUTHOR_RE.search(proc.stdout):
-            oneline = subprocess.run(
-                ["git", "log", "-1", "--oneline", commit],
-                cwd=ROOT,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-            label = oneline.stdout.strip() if oneline.returncode == 0 else commit
-            bad.append(label)
+        text = ident.stdout
+        label = commit_oneline(commit)
+        if FORBIDDEN_COAUTHOR_RE.search(text):
+            bad.append(f"{label} (Co-authored-by trailer)")
+            continue
+        # First two lines are author / committer from --format.
+        lines = text.splitlines()
+        author = lines[0] if lines else ""
+        committer = lines[1] if len(lines) > 1 else ""
+        if AGENT_IDENTITY_RE.search(author) or AGENT_IDENTITY_RE.search(committer):
+            bad.append(f"{label} (agent Author/Committer)")
     return bad
 
 
@@ -216,10 +256,10 @@ def main():
                 errors.append(f"[spanish-doc-location] {rel} (must live under an /esp directory)")
 
     try:
-        for label in commits_with_forbidden_agent_coauthor():
-            errors.append(f"[agent-coauthor] {label}")
+        for label in commits_with_forbidden_attribution():
+            errors.append(f"[commit-identity] {label}")
     except Exception as exc:
-        errors.append(f"[agent-coauthor-check] {exc}")
+        errors.append(f"[commit-identity-check] {exc}")
 
     if errors:
         print("[repo-hygiene-guard] FAILED")
@@ -232,4 +272,7 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    if "--help" in sys.argv or "-h" in sys.argv:
+        print("Usage: repo_hygiene_guard.py [--all-history]")
+        raise SystemExit(0)
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué pide esto

Los commits y PRs del agente en la nube no deben llevar **ningún** trailer de coautor (ni del agente, ni del mantenedor como coautor de un commit cuyo Author es el bot). Author y Committer: Iván Ezequiel Rodriguez. DCO con `Signed-off-by`.

Eso ya estaba en `ir0-git-commit-hygiene.md` y `CONTRIBUTING.md`. El agente de la nube lo ignoró: #56 quedó en master como `Author: Cursor Agent` más un trailer que te nombra coautor.

## Qué cambia

- Regla always-on más estricta: **cero** trailers de coautor, identidad forzada, `git commit-tree`.
- `scripts/ir0_git_commit.py` — helper que los agentes deben usar.
- `scripts/repo_hygiene_guard.py` — falla si el rango `origin/master..HEAD` tiene trailer de coautor o Author/Committer de agente. `make pre-submit` lo corre.
- `--all-history` audita master entero (hoy falla en `57c5a28` / `5b6abee` de #56).

## Historial de #56

`master` está protegido (GitHub rechaza force-push y exige PR). Este cambio **no puede** borrar esos dos trailers ya mergeados. Tras mergear esto, los **commits nuevos** quedan bloqueados si el agente vuelve a firmar como Cursor.

Para limpiar #56 en master hace falta, con protección temporalmente relajada, reescribir esa punta a la historia lineal equivalente (mismo árbol MM, Author del mantenedor).

## Identidad de este PR

Un commit, `Author`/`Committer` Iván Ezequiel Rodriguez, `Signed-off-by`, sin trailers de coautor.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f90915-231f-4526-a224-37d78303db46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f90915-231f-4526-a224-37d78303db46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

