### PR TITLE
arch: portable syscall frames, ELF machine, and ARM TLS

### DIFF
--- a/arch/arm64/sources/arch_fork.c
+++ b/arch/arm64/sources/arch_fork.c
@@ -7,37 +7,54 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: arch_fork.c
- * Description: ARM64 fork hooks — honest stubs until EL0 process parity exists.
+ * Description: ARM64 fork return / TLS (TPIDR_EL0) for portable fork.c.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
 
 #include <ir0/process.h>
 #include <ir0/arch_fork.h>
+#include <ir0/arch_cpu.h>
 #include <ir0/errno.h>
 
 int arch_fork_prepare_parent_return(struct process *parent, pid_t child_pid)
 {
 	if (!parent)
 		return 0;
-	task_set_retval(&parent->task, (uint64_t)(uint32_t)child_pid);
+
+	if (parent->mode == USER_MODE)
+	{
+		process_apply_syscall_frame_to_task(&parent->task,
+						    &parent->syscall_frame,
+						    (uint64_t)(uint32_t)child_pid);
+		set_tls(process_tls_get(parent));
+	}
+	else
+		task_set_retval(&parent->task, (uint64_t)(uint32_t)child_pid);
+
 	return 0;
 }
 
 int arch_fork_prepare_child_return(struct process *child, struct process *parent)
 {
-	(void)parent;
 	if (!child)
 		return 0;
-	/* Same contract as x86: mm/sp already set; only force fork retval 0. */
-	task_set_retval(&child->task, 0);
+
+	if (parent && parent->mode == USER_MODE)
+		process_apply_syscall_frame_to_task(&child->task,
+						    &parent->syscall_frame, 0);
+	else
+		task_set_retval(&child->task, 0);
+
 	return 0;
 }
 
 int arch_process_set_tls(struct process *proc, uint64_t tls)
 {
-	(void)proc;
-	(void)tls;
-	/* TPIDR_EL0 wiring not implemented for product ARM64 userspace yet. */
-	return -EOPNOTSUPP;
+	if (!proc)
+		return -EINVAL;
+	process_tls_set(proc, tls);
+	if (proc == current_process)
+		set_tls(tls);
+	return 0;
 }

--- a/arch/arm64/sources/arch_signal.c
+++ b/arch/arm64/sources/arch_signal.c
@@ -16,6 +16,7 @@
 
 #include <ir0/arch_signal.h>
 #include <ir0/arch_task.h>
+#include <ir0/arch_syscall_frame.h>
 #include <ir0/signals.h>
 #include <stdint.h>
 #include <string.h>
@@ -23,6 +24,55 @@
 uint64_t arch_sigcontext_ip(const struct sigcontext *ctx)
 {
 	return ctx ? ctx->pc : 0;
+}
+
+uint64_t arch_sigcontext_sp(const struct sigcontext *ctx)
+{
+	return ctx ? ctx->sp : 0;
+}
+
+void arch_signal_fill_sigcontext_from_syscall_frame(struct sigcontext *ctx,
+						    const struct arch_syscall_frame *sf,
+						    uint64_t retval)
+{
+	if (!ctx || !sf)
+		return;
+
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->regs[0] = retval;
+	ctx->regs[1] = sf->x1;
+	ctx->regs[2] = sf->x2;
+	ctx->regs[3] = sf->x3;
+	ctx->regs[4] = sf->x4;
+	ctx->regs[5] = sf->x5;
+	ctx->regs[6] = sf->x6;
+	ctx->regs[7] = sf->x7;
+	ctx->regs[8] = sf->x8;
+	ctx->regs[9] = sf->x9;
+	ctx->regs[10] = sf->x10;
+	ctx->regs[11] = sf->x11;
+	ctx->regs[12] = sf->x12;
+	ctx->regs[13] = sf->x13;
+	ctx->regs[14] = sf->x14;
+	ctx->regs[15] = sf->x15;
+	ctx->regs[16] = sf->x16;
+	ctx->regs[17] = sf->x17;
+	ctx->regs[18] = sf->x18;
+	ctx->regs[19] = sf->x19;
+	ctx->regs[20] = sf->x20;
+	ctx->regs[21] = sf->x21;
+	ctx->regs[22] = sf->x22;
+	ctx->regs[23] = sf->x23;
+	ctx->regs[24] = sf->x24;
+	ctx->regs[25] = sf->x25;
+	ctx->regs[26] = sf->x26;
+	ctx->regs[27] = sf->x27;
+	ctx->regs[28] = sf->x28;
+	ctx->regs[29] = sf->x29;
+	ctx->regs[30] = sf->x30;
+	ctx->sp = sf->sp;
+	ctx->pc = sf->elr;
+	ctx->pstate = sf->spsr;
 }
 
 void arch_signal_fill_sigcontext_from_irq_frame(struct sigcontext *ctx,

--- a/arch/arm64/sources/arch_switch.c
+++ b/arch/arm64/sources/arch_switch.c
@@ -7,13 +7,14 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: arch_switch.c
- * Description: ARM64 switch_to — TTBR0 sync, SP_EL0/SP_EL1 handoff, EL1 switch.
+ * Description: ARM64 switch_to — TTBR0, SP_EL0/SP_EL1, TPIDR_EL0 TLS, EL1 switch.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
 
 #include <ir0/arch_switch.h>
 #include <ir0/arch_task.h>
+#include <ir0/arch_cpu.h>
 #include <ir0/process.h>
 #include <stdint.h>
 
@@ -77,7 +78,27 @@ void arch_switch_to(task_t *prev, task_t *next)
 			__asm__ volatile("msr sp_el0, %0" :: "r"(sp_el0)
 					 : "memory");
 		}
+		set_tls(process_tls_get(next_proc));
 	}
 
 	switch_context_arm64(prev, next);
+}
+
+void set_fs_base(uint64_t base)
+{
+	__asm__ volatile("msr tpidr_el0, %0" :: "r"(base) : "memory");
+}
+
+uint64_t get_fs_base(void)
+{
+	uint64_t base;
+
+	__asm__ volatile("mrs %0, tpidr_el0" : "=r"(base));
+	return base;
+}
+
+void arch_restore_user_fs_base(void)
+{
+	if (current_process)
+		set_fs_base(process_tls_get(current_process));
 }

--- a/arch/arm64/sources/arch_syscall_frame.c
+++ b/arch/arm64/sources/arch_syscall_frame.c
@@ -17,21 +17,55 @@
 #include <ir0/errno.h>
 #include <kernel/process.h>
 #include <stddef.h>
+#include <string.h>
+
+static void arm64_copy_exc_gprs(arch_syscall_frame_t *sf, const uint64_t *frame)
+{
+	memcpy(&sf->x0, frame, 31 * sizeof(uint64_t));
+}
 
 void arch_process_capture_syscall_frame_at_entry(struct process *p,
 						 uint64_t *frame_base,
 						 uint64_t rip_hw)
 {
-	(void)p;
-	(void)frame_base;
-	(void)rip_hw;
+	arch_syscall_frame_t *sf;
+	uint64_t elr;
+	uint64_t spsr;
+	uint64_t sp_el0;
+
+	if (!frame_base || !p || p->mode != USER_MODE)
+		return;
+
+	sf = &p->syscall_frame;
+	arm64_copy_exc_gprs(sf, frame_base);
+
+	__asm__ volatile("mrs %0, elr_el1" : "=r"(elr));
+	__asm__ volatile("mrs %0, spsr_el1" : "=r"(spsr));
+	__asm__ volatile("mrs %0, sp_el0" : "=r"(sp_el0));
+
+	sf->elr = elr;
+	if (!sf->elr && rip_hw)
+		sf->elr = rip_hw;
+	sf->spsr = spsr;
+	sf->sp = sp_el0;
+	p->syscall_frame_fresh = 1;
+	process_sync_task_user_ip_from_syscall_frame(p);
 }
 
 void arch_process_syscall_restore_exit_regs(struct process *p,
 					    uint64_t *stack_r9_slot)
 {
-	(void)p;
-	(void)stack_r9_slot;
+	const arch_syscall_frame_t *sf;
+
+	if (!stack_r9_slot || !p || p->mode != USER_MODE)
+		return;
+
+	sf = &p->syscall_frame;
+	memcpy(stack_r9_slot, &sf->x0, 31 * sizeof(uint64_t));
+
+	__asm__ volatile("msr elr_el1, %0" :: "r"(sf->elr) : "memory");
+	__asm__ volatile("msr spsr_el1, %0" :: "r"(sf->spsr) : "memory");
+	__asm__ volatile("msr sp_el0, %0" :: "r"(sf->sp) : "memory");
 }
 
 int arch_irq_frame_is_user(const uint64_t *iretq_frame)

--- a/arch/arm64/sources/arch_task_ops.c
+++ b/arch/arm64/sources/arch_task_ops.c
@@ -158,8 +158,12 @@ void arch_task_save_irq_user_frame(task_t *t, const uint64_t *frame)
 void arch_task_sync_syscall_soft_mirror(task_t *t,
 					const arch_task_syscall_frame_t *sf)
 {
-	(void)t;
-	(void)sf;
+	if (!t || !sf)
+		return;
+
+	task_set_ip(t, sf->elr);
+	task_set_sp(t, sf->sp);
+	task_set_flags(t, sf->spsr);
 }
 
 void arch_task_apply_syscall_frame(task_t *t,
@@ -169,9 +173,40 @@ void arch_task_apply_syscall_frame(task_t *t,
 	if (!t || !sf)
 		return;
 
-	task_set_ip(t, sf->rip);
-	task_set_sp(t, sf->rsp);
-	task_set_flags(t, sf->rflags);
+	t->arch.x0 = x0;
+	t->arch.x1 = sf->x1;
+	t->arch.x2 = sf->x2;
+	t->arch.x3 = sf->x3;
+	t->arch.x4 = sf->x4;
+	t->arch.x5 = sf->x5;
+	t->arch.x6 = sf->x6;
+	t->arch.x7 = sf->x7;
+	t->arch.x8 = sf->x8;
+	t->arch.x9 = sf->x9;
+	t->arch.x10 = sf->x10;
+	t->arch.x11 = sf->x11;
+	t->arch.x12 = sf->x12;
+	t->arch.x13 = sf->x13;
+	t->arch.x14 = sf->x14;
+	t->arch.x15 = sf->x15;
+	t->arch.x16 = sf->x16;
+	t->arch.x17 = sf->x17;
+	t->arch.x18 = sf->x18;
+	t->arch.x19 = sf->x19;
+	t->arch.x20 = sf->x20;
+	t->arch.x21 = sf->x21;
+	t->arch.x22 = sf->x22;
+	t->arch.x23 = sf->x23;
+	t->arch.x24 = sf->x24;
+	t->arch.x25 = sf->x25;
+	t->arch.x26 = sf->x26;
+	t->arch.x27 = sf->x27;
+	t->arch.x28 = sf->x28;
+	t->arch.x29 = sf->x29;
+	t->arch.x30 = sf->x30;
+	task_set_ip(t, sf->elr);
+	task_set_sp(t, sf->sp);
+	task_set_flags(t, sf->spsr);
 	task_set_retval(t, x0);
 }
 

--- a/arch/arm64/sources/busybox_load_early.c
+++ b/arch/arm64/sources/busybox_load_early.c
@@ -14,11 +14,11 @@
 #include "syscall_early.h"
 
 #include <stdint.h>
+#include <ir0/arch_elf.h>
 #include <ir0/boot_log.h>
 
 #define EI_NIDENT 16
 #define ET_EXEC 2
-#define EM_AARCH64 183
 #define PT_LOAD 1
 #define PF_X 1
 #define PAGE_SIZE 4096UL
@@ -152,7 +152,7 @@ static int load_elf(const uint8_t *blob, uint64_t blob_len, uint64_t *entry_out)
 	if (ehdr->e_ident[0] != 0x7f || ehdr->e_ident[1] != 'E' ||
 	    ehdr->e_ident[2] != 'L' || ehdr->e_ident[3] != 'F')
 		return -1;
-	if (ehdr->e_type != ET_EXEC || ehdr->e_machine != EM_AARCH64)
+	if (ehdr->e_type != ET_EXEC || !arch_elf_machine_supported(ehdr->e_machine))
 		return -1;
 	if (ehdr->e_phoff + (uint64_t)ehdr->e_phnum * ehdr->e_phentsize > blob_len)
 		return -1;

--- a/arch/arm64/sources/elf_load_early.c
+++ b/arch/arm64/sources/elf_load_early.c
@@ -12,11 +12,11 @@
 #include "pl011.h"
 
 #include <stdint.h>
+#include <ir0/arch_elf.h>
 #include <ir0/boot_log.h>
 
 #define EI_NIDENT 16
 #define ET_EXEC 2
-#define EM_AARCH64 183
 #define PT_LOAD 1
 #define PF_X 1
 #define PAGE_SIZE 4096UL
@@ -130,7 +130,7 @@ static int load_elf(const uint8_t *blob, uint64_t blob_len, uint64_t *entry_out)
 	if (ehdr->e_ident[0] != 0x7f || ehdr->e_ident[1] != 'E' ||
 	    ehdr->e_ident[2] != 'L' || ehdr->e_ident[3] != 'F')
 		return -1;
-	if (ehdr->e_type != ET_EXEC || ehdr->e_machine != EM_AARCH64)
+	if (ehdr->e_type != ET_EXEC || !arch_elf_machine_supported(ehdr->e_machine))
 		return -1;
 	if (ehdr->e_phoff + (uint64_t)ehdr->e_phnum * ehdr->e_phentsize > blob_len)
 		return -1;

--- a/arch/x86-64/sources/arch_signal.c
+++ b/arch/x86-64/sources/arch_signal.c
@@ -14,11 +14,49 @@
 
 #include <ir0/arch_signal.h>
 #include <ir0/arch_task.h>
+#include <ir0/arch_syscall_frame.h>
 #include <ir0/signals.h>
+#include <config.h>
+#include <string.h>
 
 uint64_t arch_sigcontext_ip(const struct sigcontext *ctx)
 {
 	return ctx ? ctx->rip : 0;
+}
+
+uint64_t arch_sigcontext_sp(const struct sigcontext *ctx)
+{
+	return ctx ? ctx->rsp : 0;
+}
+
+void arch_signal_fill_sigcontext_from_syscall_frame(struct sigcontext *ctx,
+						    const struct arch_syscall_frame *sf,
+						    uint64_t retval)
+{
+	if (!ctx || !sf)
+		return;
+
+	memset(ctx, 0, sizeof(*ctx));
+	ctx->rip = sf->rip;
+	ctx->rsp = sf->rsp;
+	ctx->rflags = sf->rflags ? sf->rflags : (uint64_t)RFLAGS_IF;
+	ctx->rax = retval;
+	ctx->rdi = sf->rdi;
+	ctx->rsi = sf->rsi;
+	ctx->rdx = sf->rdx;
+	ctx->r10 = sf->r10;
+	ctx->r8 = sf->r8;
+	ctx->r9 = sf->r9;
+	ctx->rbx = sf->rbx;
+	ctx->rbp = sf->rbp;
+	ctx->r12 = sf->r12;
+	ctx->r13 = sf->r13;
+	ctx->r14 = sf->r14;
+	ctx->r15 = sf->r15;
+#if defined(USER_CODE_SEL) && defined(USER_DATA_SEL)
+	ctx->cs = (uint64_t)USER_CODE_SEL;
+	ctx->ss = (uint64_t)USER_DATA_SEL;
+#endif
 }
 
 void arch_signal_fill_sigcontext_from_irq_frame(struct sigcontext *ctx,

--- a/arch/x86-64/sources/arch_switch.c
+++ b/arch/x86-64/sources/arch_switch.c
@@ -174,7 +174,12 @@ static void wait_exit_audit_ctx_resume(process_t *prev_proc, process_t *next_pro
 
 void arch_switch_to(task_t *prev, task_t *next)
 {
-process_t *prev_proc;
+    /*
+     * High-regression area: wait4, irq_frame_saved, syscall_resume_rax,
+     * and kernel_ret vs user-iret. Do not simplify these gates without
+     * wait4 + blocked-syscall coverage.
+     */
+    process_t *prev_proc;
     process_t *next_proc = NULL;
 
     if (next)

--- a/includes/ir0/arch_cpu.h
+++ b/includes/ir0/arch_cpu.h
@@ -7,8 +7,8 @@
  * Distributed under the terms of the GNU General Public License v3.0.
  * See the LICENSE file in the project root for full license information.
  *
- * File: arch_portable.h
- * Description: IR0 kernel source/header file
+ * File: arch_cpu.h
+ * Description: Portable CPU/TLS/MM activate facades (x86 FS / ARM TPIDR, CR3/TTBR).
  */
 
 // ===============================================================================

--- a/includes/ir0/arch_cpu.h
+++ b/includes/ir0/arch_cpu.h
@@ -238,17 +238,16 @@ struct process;
 void first_switch_to(struct process *next);
 
 /*
- * set_fs_base - Set x86-64 FS base (TLS) for the running hardware thread.
- * Used by sys_arch_prctl(ARCH_SET_FS). No-op on non-x86 builds.
+ * set_fs_base - Install the running thread's TLS base.
+ * x86-64: IA32_FS_BASE. ARM64: TPIDR_EL0. Prefer set_tls() from portable code.
  */
 void set_fs_base(uint64_t base);
 
-/* Re-apply current_process->fs_base before sysret / user iretq. */
+/* Re-apply current_process TLS before returning to userspace. */
 void arch_restore_user_fs_base(void);
 
 /*
- * set_tls - Portable TLS base install (x86: FS base; other arch: stub).
- * Prefer this from portable code instead of CPUID/MSR details.
+ * set_tls - Portable TLS base install (x86: FS base; ARM64: TPIDR_EL0).
  */
 static inline void set_tls(uint64_t base)
 {
@@ -325,7 +324,7 @@ uint64_t mm_make_leaf_pte(uintptr_t phys, uint64_t flags12, int exec);
 void mm_pte_set_user(uint64_t *e);
 
 /*
- * get_fs_base - Read x86-64 FS base MSR.
+ * get_fs_base - Read the running thread's TLS base (x86 FS / ARM TPIDR_EL0).
  */
 uint64_t get_fs_base(void);
 

--- a/includes/ir0/arch_elf.h
+++ b/includes/ir0/arch_elf.h
@@ -1,0 +1,32 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: arch_elf.h
+ * Description: ELF e_machine accepted by this kernel build (portable loader).
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#pragma once
+
+#include <stdint.h>
+
+/* ELF e_machine values (System V ABI). */
+#define ELF_EM_X86_64  62
+#define ELF_EM_AARCH64 183
+
+#if defined(ARCH_ARM64) || defined(__aarch64__)
+#define ARCH_ELF_MACHINE ELF_EM_AARCH64
+#else
+#define ARCH_ELF_MACHINE ELF_EM_X86_64
+#endif
+
+static inline int arch_elf_machine_supported(uint16_t machine)
+{
+	return machine == (uint16_t)ARCH_ELF_MACHINE;
+}

--- a/includes/ir0/arch_signal.h
+++ b/includes/ir0/arch_signal.h
@@ -18,9 +18,19 @@
 #include <ir0/task.h>
 
 struct sigcontext;
+struct arch_syscall_frame;
 
-/* Instruction pointer from an ISA-specific sigcontext (rip / pc). */
+/* Instruction pointer / stack from an ISA-specific sigcontext (rip/pc, rsp/sp). */
 uint64_t arch_sigcontext_ip(const struct sigcontext *ctx);
+uint64_t arch_sigcontext_sp(const struct sigcontext *ctx);
+
+/*
+ * Fill @ctx from a captured syscall frame (musl syscall insn while blocked).
+ * @retval is the interrupted syscall return (typically -EINTR).
+ */
+void arch_signal_fill_sigcontext_from_syscall_frame(struct sigcontext *ctx,
+						    const struct arch_syscall_frame *sf,
+						    uint64_t retval);
 
 void arch_signal_fill_sigcontext_from_irq_frame(struct sigcontext *ctx,
 						const uint64_t *frame);

--- a/includes/ir0/arch_syscall_frame.h
+++ b/includes/ir0/arch_syscall_frame.h
@@ -7,10 +7,10 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: arch_syscall_frame.h
- * Description: ISA hooks for syscall/IRQ user-frame capture (portable core.c).
+ * Description: ISA syscall-frame type + capture/restore hooks for portable core.
  *
- * Storage type: arch_syscall_frame_t in kernel/process.h (legacy alias
- * syscall_user_frame_t). This header only declares ISA capture/restore ops.
+ * Storage: arch_syscall_frame_t is selected from arch_syscall_frame_{x86_64,arm64}.h.
+ * Semantic accessors live with the layout. Decode/fill stays in arch backends.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -20,6 +20,15 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <ir0/task.h>
+
+#if defined(ARCH_ARM64) || defined(__aarch64__)
+#include <ir0/arch_syscall_frame_arm64.h>
+#else
+#include <ir0/arch_syscall_frame_x86_64.h>
+#endif
+
+/* Legacy alias — same type; do not invent a second frame layout. */
+typedef arch_syscall_frame_t syscall_user_frame_t;
 
 struct process;
 

--- a/includes/ir0/arch_syscall_frame_arm64.h
+++ b/includes/ir0/arch_syscall_frame_arm64.h
@@ -1,0 +1,157 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: arch_syscall_frame_arm64.h
+ * Description: Linux AArch64 syscall user-frame and semantic accessors.
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Snapshot of EL0 GPRs + exception return state at SVC entry.
+ * Layout matches vectors.S exc_entry_frame (x0@0 … x30@240) plus ELR/SPSR/SP.
+ * Portable code must use arch_syscall_frame_ip/sp/flags/arg.
+ *
+ * Linux AAPCS64 syscall ABI: number in x8, args x0–x5, retval in x0.
+ */
+typedef struct arch_syscall_frame
+{
+	uint64_t x0;
+	uint64_t x1;
+	uint64_t x2;
+	uint64_t x3;
+	uint64_t x4;
+	uint64_t x5;
+	uint64_t x6;
+	uint64_t x7;
+	uint64_t x8;
+	uint64_t x9;
+	uint64_t x10;
+	uint64_t x11;
+	uint64_t x12;
+	uint64_t x13;
+	uint64_t x14;
+	uint64_t x15;
+	uint64_t x16;
+	uint64_t x17;
+	uint64_t x18;
+	uint64_t x19;
+	uint64_t x20;
+	uint64_t x21;
+	uint64_t x22;
+	uint64_t x23;
+	uint64_t x24;
+	uint64_t x25;
+	uint64_t x26;
+	uint64_t x27;
+	uint64_t x28;
+	uint64_t x29;
+	uint64_t x30;
+	uint64_t sp;
+	uint64_t elr;
+	uint64_t spsr;
+} arch_syscall_frame_t;
+
+_Static_assert(offsetof(arch_syscall_frame_t, x30) == 30 * sizeof(uint64_t),
+	       "x0..x30 packed for vectors.S exc_entry_frame");
+_Static_assert(offsetof(arch_syscall_frame_t, sp) == 31 * sizeof(uint64_t),
+	       "sp follows x30");
+
+static inline uint64_t arch_syscall_frame_ip(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->elr : 0;
+}
+
+static inline uint64_t arch_syscall_frame_sp(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->sp : 0;
+}
+
+static inline uint64_t arch_syscall_frame_flags(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->spsr : 0;
+}
+
+static inline void arch_syscall_frame_set_ip(arch_syscall_frame_t *sf, uint64_t ip)
+{
+	if (sf)
+		sf->elr = ip;
+}
+
+static inline void arch_syscall_frame_set_sp(arch_syscall_frame_t *sf, uint64_t sp)
+{
+	if (sf)
+		sf->sp = sp;
+}
+
+static inline void arch_syscall_frame_set_flags(arch_syscall_frame_t *sf,
+						uint64_t flags)
+{
+	if (sf)
+		sf->spsr = flags;
+}
+
+/* Linux AArch64 syscall ABI: args x0–x5. */
+static inline uint64_t arch_syscall_frame_arg(const arch_syscall_frame_t *sf,
+					      unsigned n)
+{
+	if (!sf)
+		return 0;
+	switch (n)
+	{
+	case 0:
+		return sf->x0;
+	case 1:
+		return sf->x1;
+	case 2:
+		return sf->x2;
+	case 3:
+		return sf->x3;
+	case 4:
+		return sf->x4;
+	case 5:
+		return sf->x5;
+	default:
+		return 0;
+	}
+}
+
+static inline void arch_syscall_frame_set_arg(arch_syscall_frame_t *sf,
+					      unsigned n, uint64_t v)
+{
+	if (!sf)
+		return;
+	switch (n)
+	{
+	case 0:
+		sf->x0 = v;
+		break;
+	case 1:
+		sf->x1 = v;
+		break;
+	case 2:
+		sf->x2 = v;
+		break;
+	case 3:
+		sf->x3 = v;
+		break;
+	case 4:
+		sf->x4 = v;
+		break;
+	case 5:
+		sf->x5 = v;
+		break;
+	default:
+		break;
+	}
+}

--- a/includes/ir0/arch_syscall_frame_x86_64.h
+++ b/includes/ir0/arch_syscall_frame_x86_64.h
@@ -1,0 +1,129 @@
+/**
+ * IR0 Kernel — Core system software
+ * Copyright (C) 2026  Iván Rodriguez
+ *
+ * This file is part of the IR0 Operating System.
+ * Distributed under the terms of the GNU General Public License v3.0.
+ * See the LICENSE file in the project root for full license information.
+ *
+ * File: arch_syscall_frame_x86_64.h
+ * Description: Linux x86-64 syscall user-frame (pt_regs subset) and accessors.
+ */
+
+/* SPDX-License-Identifier: GPL-3.0-only */
+
+#pragma once
+
+#include <stdint.h>
+
+/*
+ * Layout matches syscall_insn_entry_64.asm capture. Portable code must use
+ * arch_syscall_frame_ip/sp/flags/arg — not these GPR names.
+ */
+typedef struct arch_syscall_frame
+{
+	uint64_t rip;
+	uint64_t rflags;
+	uint64_t rsp;
+	uint64_t rbx;
+	uint64_t rbp;
+	uint64_t r12;
+	uint64_t r13;
+	uint64_t r14;
+	uint64_t r15;
+	uint64_t rdi;
+	uint64_t rsi;
+	uint64_t rdx;
+	uint64_t r10;
+	uint64_t r8;
+	uint64_t r9;
+} arch_syscall_frame_t;
+
+static inline uint64_t arch_syscall_frame_ip(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->rip : 0;
+}
+
+static inline uint64_t arch_syscall_frame_sp(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->rsp : 0;
+}
+
+static inline uint64_t arch_syscall_frame_flags(const arch_syscall_frame_t *sf)
+{
+	return sf ? sf->rflags : 0;
+}
+
+static inline void arch_syscall_frame_set_ip(arch_syscall_frame_t *sf, uint64_t ip)
+{
+	if (sf)
+		sf->rip = ip;
+}
+
+static inline void arch_syscall_frame_set_sp(arch_syscall_frame_t *sf, uint64_t sp)
+{
+	if (sf)
+		sf->rsp = sp;
+}
+
+static inline void arch_syscall_frame_set_flags(arch_syscall_frame_t *sf,
+						uint64_t flags)
+{
+	if (sf)
+		sf->rflags = flags;
+}
+
+/* Linux x86-64 syscall ABI: 0=rdi, 1=rsi, 2=rdx, 3=r10, 4=r8, 5=r9. */
+static inline uint64_t arch_syscall_frame_arg(const arch_syscall_frame_t *sf,
+					      unsigned n)
+{
+	if (!sf)
+		return 0;
+	switch (n)
+	{
+	case 0:
+		return sf->rdi;
+	case 1:
+		return sf->rsi;
+	case 2:
+		return sf->rdx;
+	case 3:
+		return sf->r10;
+	case 4:
+		return sf->r8;
+	case 5:
+		return sf->r9;
+	default:
+		return 0;
+	}
+}
+
+static inline void arch_syscall_frame_set_arg(arch_syscall_frame_t *sf,
+					      unsigned n, uint64_t v)
+{
+	if (!sf)
+		return;
+	switch (n)
+	{
+	case 0:
+		sf->rdi = v;
+		break;
+	case 1:
+		sf->rsi = v;
+		break;
+	case 2:
+		sf->rdx = v;
+		break;
+	case 3:
+		sf->r10 = v;
+		break;
+	case 4:
+		sf->r8 = v;
+		break;
+	case 5:
+		sf->r9 = v;
+		break;
+	default:
+		break;
+	}
+}

--- a/includes/ir0/arch_task_ops.h
+++ b/includes/ir0/arch_task_ops.h
@@ -17,29 +17,13 @@
 #include <stdint.h>
 #include <ir0/signals.h>
 #include <ir0/task.h>
+#include <ir0/arch_syscall_frame.h>
 
 /*
- * Linux pt_regs subset mirrored for arch backends — layout matches
- * process.h syscall_user_frame_t without including process.h here.
+ * Same storage as process_t.syscall_frame. Arch backends may open ISA fields;
+ * portable code uses arch_syscall_frame_* / process_syscall_*.
  */
-typedef struct arch_task_syscall_frame
-{
-	uint64_t rip;
-	uint64_t rflags;
-	uint64_t rsp;
-	uint64_t rbx;
-	uint64_t rbp;
-	uint64_t r12;
-	uint64_t r13;
-	uint64_t r14;
-	uint64_t r15;
-	uint64_t rdi;
-	uint64_t rsi;
-	uint64_t rdx;
-	uint64_t r10;
-	uint64_t r8;
-	uint64_t r9;
-} arch_task_syscall_frame_t;
+typedef arch_syscall_frame_t arch_task_syscall_frame_t;
 
 void arch_task_apply_syscall_frame(task_t *task,
 				   const arch_task_syscall_frame_t *sf,

--- a/includes/ir0/process.h
+++ b/includes/ir0/process.h
@@ -7,14 +7,17 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: process.h
- * Description: Process/task public API facade (implementation in kernel/process.c).
- *              Include as <ir0/process.h>; do not include <kernel/process.h> elsewhere.
+ * Description: Process/task public include. Layout is not fully encapsulated yet.
+ *
+ * Include as <ir0/process.h>. kernel/process.h still publishes process_t
+ * (signals, wait, blocked-syscall resume, creds, timers, stacks, ...).
+ * Domain extraction is in progress (mm_struct, files_struct); new code
+ * should use accessors rather than growing the struct further.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
 
 #pragma once
-
 
 #include <kernel/process.h>
 

--- a/includes/ir0/signals.c
+++ b/includes/ir0/signals.c
@@ -634,39 +634,15 @@ void handle_signals(void)
                          * while blocked in recvfrom/nanosleep.
                          */
                         if (current->syscall_frame_fresh)
-                        {
-                            const syscall_user_frame_t *sf =
-                                &current->syscall_frame;
-
-                            memset(ctx, 0, sizeof(*ctx));
-                            ctx->rip = sf->rip;
-                            ctx->rsp = sf->rsp;
-                            ctx->rflags = sf->rflags ? sf->rflags
-                                                     : (uint64_t)RFLAGS_IF;
-                            ctx->rax = (uint64_t)(int64_t)(-EINTR);
-                            ctx->rdi = sf->rdi;
-                            ctx->rsi = sf->rsi;
-                            ctx->rdx = sf->rdx;
-                            ctx->r10 = sf->r10;
-                            ctx->r8 = sf->r8;
-                            ctx->r9 = sf->r9;
-                            ctx->rbx = sf->rbx;
-                            ctx->rbp = sf->rbp;
-                            ctx->r12 = sf->r12;
-                            ctx->r13 = sf->r13;
-                            ctx->r14 = sf->r14;
-                            ctx->r15 = sf->r15;
-#if defined(USER_CODE_SEL) && defined(USER_DATA_SEL)
-                            ctx->cs = (uint64_t)USER_CODE_SEL;
-                            ctx->ss = (uint64_t)USER_DATA_SEL;
-#endif
-                        }
+                            arch_signal_fill_sigcontext_from_syscall_frame(
+                                ctx, &current->syscall_frame,
+                                (uint64_t)(int64_t)(-EINTR));
                         else
                             arch_task_store_sigcontext(ctx, &current->task);
 
                         current->saved_context = ctx;
 
-                        user_sp = ctx->rsp & ~0xFUL;
+                        user_sp = arch_sigcontext_sp(ctx) & ~0xFUL;
                         /*
                          * Layout (low→high): [restorer][sigframe…]
                          * Handler `ret` → musl __restore_rt → rt_sigreturn.

--- a/kernel/elf_loader.c
+++ b/kernel/elf_loader.c
@@ -446,10 +446,10 @@ static int elf_load_segments(elf64_header_t *header, uint8_t *file_data, size_t 
     return 0;
 }
 
-/* Dummy entry function for ELF processes (will be overridden) */
+/* Dummy entry: spawn() needs a function pointer; ELF overwrites the IP. */
 static void elf_dummy_entry(void)
 {
-    /* This should never be called as we override RIP */
+    /* This should never be called as we override the task IP */
     panic("ELF dummy entry should never be called :)\n");
 }
 
@@ -500,10 +500,10 @@ static process_t *elf_create_process(elf64_header_t *header, const char *path)
     task_set_ip(&process->task, header->e_entry);
     arch_task_set_user_segments(&process->task);
 
-    /* Stack is already set up by spawn() at 0x7FFFF000 */
+    /* Stack window is USER_STACK_TOP (spawn_user / process_set_stack_layout). */
 
     /* Enable interrupts in user mode */
-    task_set_flags(&process->task, ir0_rflags_sanitize_user(0x202ULL));
+    task_set_flags(&process->task, ir0_rflags_sanitize_user(RFLAGS_IF));
 
     klog_debug_fmt("ELF", "SERIAL: ELF: Process created with PID %x", (unsigned)(process->task.pid));
     klog_debug_fmt("ELF", "SERIAL: ELF: Entry point: 0x%x", (unsigned)((uint32_t)task_get_ip(&process->task)));
@@ -513,22 +513,13 @@ static process_t *elf_create_process(elf64_header_t *header, const char *path)
 }
 
 /**
- * elf_setup_stack - Initialize stack with argc, argv, envp (x86-64 ABI)
+ * elf_setup_stack - argc/argv/envp + auxv (SysV ABI stack; ISA-neutral).
  * @process: Process to set up stack for
  * @argv: Command line arguments (NULL-terminated)
  * @envp: Environment variables (NULL-terminated)
- * 
- * Sets up the stack according to x86-64 ABI:
- * - argc at bottom of stack
- * - argv[] array (pointers, NULL-terminated)
- * - envp[] array (pointers, NULL-terminated)
- * - Argument strings
- * - Environment strings
- * 
- * Registers will be set by context switch:
- * - rdi = argc
- * - rsi = argv
- * - rdx = envp
+ *
+ * Stack: argc, argv[], envp[], auxv, strings.
+ * Entry registers (task_set_arg0/1/2): argc, argv, envp.
  */
 static int elf_setup_stack(process_t *process, char *const argv[], char *const envp[],
                            const elf64_header_t *header, uint64_t at_phdr,
@@ -791,10 +782,10 @@ static int elf_setup_stack(process_t *process, char *const argv[], char *const e
     task_set_sp(&process->task, argc_slot);
     arch_task_set_frame_pointer(&process->task, argc_slot);
 
-    /* Set registers for x86-64 ABI: rdi=argc, rsi=argv, rdx=envp */
+    /* SysV entry: arg0=argc, arg1=argv, arg2=envp (x86 rdi/rsi/rdx, ARM x0/x1/x2). */
     task_set_arg0(&process->task, (uint64_t)argc);
-    task_set_rsi(&process->task, argv_array);
-    task_set_rdx(&process->task, envp_array);
+    task_set_arg1(&process->task, argv_array);
+    task_set_arg2(&process->task, envp_array);
 
     kfree(argv_ptrs);
     kfree(envp_ptrs);
@@ -1332,7 +1323,7 @@ int exec_replace_current(const char *path, char *const argv[], char *const envp[
     task_set_ip(&proc->task, header->e_entry);
     exec_commit_ctx.entry_rip = header->e_entry;
     arch_task_set_user_segments(&proc->task);
-    task_set_flags(&proc->task, ir0_rflags_sanitize_user(0x202ULL));
+    task_set_flags(&proc->task, ir0_rflags_sanitize_user(RFLAGS_IF));
 
     if (elf_setup_stack(proc, argv, envp, header, at_phdr, at_base,
                         "exec_replace_current", path) != 0)

--- a/kernel/elf_loader.c
+++ b/kernel/elf_loader.c
@@ -14,6 +14,7 @@
 
 #include "process.h"
 #include <ir0/arch_task.h>
+#include <ir0/arch_elf.h>
 #include <ir0/sched.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -83,7 +84,6 @@ typedef struct
 #define ET_EXEC 2
 #define ET_DYN  3
 #define PT_LOAD 1
-#define EM_X86_64 0x3e
 
 /* Maximum program headers processed per executable (bounds cost and table size) */
 #define ELF_MAX_PHNUM 64
@@ -209,8 +209,9 @@ static int validate_elf_header(const elf64_header_t *header)
         return 0;
     }
 
-    /* Check 64-bit and x86-64 architecture */
-    if (header->e_ident[4] != ELFCLASS64 || header->e_machine != EM_X86_64)
+    /* Check 64-bit ELF for this kernel's e_machine. */
+    if (header->e_ident[4] != ELFCLASS64 ||
+        !arch_elf_machine_supported(header->e_machine))
     {
         return 0;
     }
@@ -1278,13 +1279,13 @@ int exec_replace_current(const char *path, char *const argv[], char *const envp[
     process_set_heap_start(proc, 0);
     process_set_heap_end(proc, 0);
     /*
-     * Linux clears TLS across execve. Stale fs_base from the pre-exec image
+     * Linux clears TLS across execve. Stale tls_base from the pre-exec image
      * (or fork parent) must not be restored on the next context switch —
-     * that leaves FS pointing at unmapped VA while glibc/musl still expect
-     * to call arch_prctl(ARCH_SET_FS) during CRT startup.
+     * that leaves TLS pointing at unmapped VA while glibc/musl still expect
+     * to install a new base during CRT startup (x86: arch_prctl; ARM: TPIDR).
      */
     process_tls_set(proc, 0);
-    set_fs_base(0);
+    set_tls(0);
     process_set_stack_layout(proc, USER_STACK_TOP - USER_STACK_SIZE,
 			     USER_STACK_SIZE);
 

--- a/kernel/process.c
+++ b/kernel/process.c
@@ -16,6 +16,9 @@
  * Process ownership split (ARCH process monolith):
  *   kernel/process/core.c      — list, PID, syscall frame
  *   kernel/process/create.c    — spawn
+ *   kernel/process/domains.c   — mm/files attach
+ *   kernel/process/mm_struct.c — address-space domain
+ *   kernel/process/files_struct.c — fd-table domain
  *   kernel/process/fork.c      — fork + rollback
  *   kernel/process/exec.c      — CLOEXEC on exec
  *   kernel/process/exit.c      — exit → zombie, destroy on reap

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -7,7 +7,9 @@
  * See the LICENSE file in the project root for full license information.
  *
  * File: process.h
- * Description: IR0 kernel source/header file
+ * Description: process_t and process API. Still a large aggregate (sched,
+ *              signals, wait, blocked-syscall resume, creds, timers, stacks);
+ *              mm/files are already extracted. Prefer accessors.
  */
 
 /* SPDX-License-Identifier: GPL-3.0-only */
@@ -18,6 +20,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <ir0/task.h>
+#include <ir0/arch_syscall_frame.h>
 #include <ir0/signals.h>
 #include <ir0/types.h>
 #include <ir0/fd_types.h>
@@ -88,35 +91,9 @@ struct mmap_region
 };
 
 /*
- * User register snapshot at syscall entry (Linux pt_regs subset).
- * Prefer the ISA-neutral name arch_syscall_frame_t in new code.
- * Layout decode/fill remains ISA-private (arch_syscall_frame / arch_switch).
- */
-typedef struct
-{
-	uint64_t rip;
-	uint64_t rflags;
-	uint64_t rsp;
-	uint64_t rbx;
-	uint64_t rbp;
-	uint64_t r12;
-	uint64_t r13;
-	uint64_t r14;
-	uint64_t r15;
-	uint64_t rdi;
-	uint64_t rsi;
-	uint64_t rdx;
-	uint64_t r10;
-	uint64_t r8;
-	uint64_t r9;
-} arch_syscall_frame_t;
-
-/* Legacy alias — same type; do not invent a second frame layout. */
-typedef arch_syscall_frame_t syscall_user_frame_t;
-
-/*
- * Arch-owned thread TLS (x86: IA32_FS_BASE). Lives in a union with fs_base so
- * ASM IR0_PROC_FS_BASE_OFFSET stays stable; portable code uses process_tls_*.
+ * Arch-owned thread TLS (x86: IA32_FS_BASE; ARM64: TPIDR_EL0). Lives in a
+ * union with fs_base so ASM IR0_PROC_FS_BASE_OFFSET stays stable; portable
+ * code uses process_tls_*.
  */
 typedef struct arch_thread_state
 {
@@ -125,6 +102,10 @@ typedef struct arch_thread_state
 
 typedef struct process
 {
+	/*
+	 * Aggregate still owns lifecycle, signals, wait, syscall-resume, creds,
+	 * timers, and stacks. mm and files are the extracted domains so far.
+	 */
 	task_t task;
 	/*
 	 * TLS / arch thread state. Prefer process_tls_get/set and
@@ -449,91 +430,49 @@ static inline void process_tls_set(process_t *p, uint64_t tls)
 		p->arch_thread.tls_base = tls;
 }
 
-/* Opaque syscall-frame accessors (layout is ISA-shaped; do not open-code fields). */
+/* Opaque syscall-frame accessors — ISA decode lives in arch_syscall_frame_*.h. */
 static inline uint64_t process_syscall_ip(const process_t *p)
 {
-	return p ? p->syscall_frame.rip : 0;
+	return p ? arch_syscall_frame_ip(&p->syscall_frame) : 0;
 }
 
 static inline uint64_t process_syscall_sp(const process_t *p)
 {
-	return p ? p->syscall_frame.rsp : 0;
+	return p ? arch_syscall_frame_sp(&p->syscall_frame) : 0;
 }
 
 static inline uint64_t process_syscall_flags(const process_t *p)
 {
-	return p ? p->syscall_frame.rflags : 0;
+	return p ? arch_syscall_frame_flags(&p->syscall_frame) : 0;
 }
 
 static inline void process_syscall_set_ip(process_t *p, uint64_t ip)
 {
 	if (p)
-		p->syscall_frame.rip = ip;
+		arch_syscall_frame_set_ip(&p->syscall_frame, ip);
 }
 
 static inline void process_syscall_set_sp(process_t *p, uint64_t sp)
 {
 	if (p)
-		p->syscall_frame.rsp = sp;
+		arch_syscall_frame_set_sp(&p->syscall_frame, sp);
 }
 
 static inline void process_syscall_set_flags(process_t *p, uint64_t flags)
 {
 	if (p)
-		p->syscall_frame.rflags = flags;
+		arch_syscall_frame_set_flags(&p->syscall_frame, flags);
 }
 
-/* Linux x86-64 ABI arg slots: 0=rdi … 5=r9 (ARM64 maps later). */
 static inline uint64_t process_syscall_arg(const process_t *p, unsigned n)
 {
-	if (!p)
-		return 0;
-	switch (n)
-	{
-	case 0:
-		return p->syscall_frame.rdi;
-	case 1:
-		return p->syscall_frame.rsi;
-	case 2:
-		return p->syscall_frame.rdx;
-	case 3:
-		return p->syscall_frame.r10;
-	case 4:
-		return p->syscall_frame.r8;
-	case 5:
-		return p->syscall_frame.r9;
-	default:
-		return 0;
-	}
+	return p ? arch_syscall_frame_arg(&p->syscall_frame, n) : 0;
 }
 
 static inline void process_syscall_set_arg(process_t *p, unsigned n, uint64_t v)
 {
-	if (!p)
-		return;
-	switch (n)
-	{
-	case 0:
-		p->syscall_frame.rdi = v;
-		break;
-	case 1:
-		p->syscall_frame.rsi = v;
-		break;
-	case 2:
-		p->syscall_frame.rdx = v;
-		break;
-	case 3:
-		p->syscall_frame.r10 = v;
-		break;
-	case 4:
-		p->syscall_frame.r8 = v;
-		break;
-	case 5:
-		p->syscall_frame.r9 = v;
-		break;
-	default:
-		break;
-	}
+	if (p)
+		arch_syscall_frame_set_arg(&p->syscall_frame, n, v);
 }
 
 void process_capture_syscall_frame(process_t *p);

--- a/kernel/process.h
+++ b/kernel/process.h
@@ -490,6 +490,7 @@ void process_arm_blocked_syscall_resume(process_t *p, uint64_t rax);
 void process_arm_coop_resched_resume(process_t *p, uint64_t rax);
 void process_clear_in_thread_syscall_block(process_t *p);
 void process_reset_blocked_syscall_state(process_t *p);
+/* "arm" = prepare/enable a resume path (English verb), not ARM64. */
 void process_arm_kernel_syscall_sleep(process_t *p);
 /* After switch_context saved prev: honour want_kernel_ret (Class B close). */
 void process_after_task_save(task_t *prev);
@@ -583,15 +584,14 @@ int process_signal_default_kill(process_t *target, int signal);
  */
 void process_reap_zombie_on_wait_resume(process_t *parent, pid_t child_pid);
 
-/* IR0 PHILOSOPHY: Only spawn() creates processes - total simplicity
- * Mode must be explicitly specified - no magic address detection */
+/* spawn() — explicit-mode process creation (kernel vs user). */
 pid_t spawn(void (*entry)(void), const char *name, process_mode_t mode);
 
 /* Convenience wrappers for explicit mode specification */
 pid_t spawn_user(void (*entry)(void), const char *name);
 pid_t spawn_kernel(void (*entry)(void), const char *name);
 
-/* Fork exists only for POSIX syscall compatibility - uses spawn() internally */
+/* POSIX fork/clone: kernel/process/fork.c (not spawn internally). */
 pid_t fork(void);
 pid_t clone_thread(unsigned long flags, void *stack, int *parent_tid,
 		   int *child_tid, unsigned long tls);

--- a/kernel/process/core.c
+++ b/kernel/process/core.c
@@ -25,21 +25,7 @@ static void syscall_frame_to_arch(const syscall_user_frame_t *sf,
 	if (!sf || !out)
 		return;
 
-	out->rip = sf->rip;
-	out->rflags = sf->rflags;
-	out->rsp = sf->rsp;
-	out->rbx = sf->rbx;
-	out->rbp = sf->rbp;
-	out->r12 = sf->r12;
-	out->r13 = sf->r13;
-	out->r14 = sf->r14;
-	out->r15 = sf->r15;
-	out->rdi = sf->rdi;
-	out->rsi = sf->rsi;
-	out->rdx = sf->rdx;
-	out->r10 = sf->r10;
-	out->r8 = sf->r8;
-	out->r9 = sf->r9;
+	*out = *sf;
 }
 
 int process_task_kernel_ret_rip_bad(const task_t *t)
@@ -228,14 +214,7 @@ void process_sync_task_user_ip_from_syscall_frame(process_t *p)
 		return;
 
 	sf = &p->syscall_frame;
-	{
-		arch_task_syscall_frame_t arch_sf;
-
-		arch_sf.rip = sf->rip;
-		arch_sf.rflags = sf->rflags;
-		arch_sf.rsp = sf->rsp;
-		arch_task_sync_syscall_soft_mirror(&p->task, &arch_sf);
-	}
+	arch_task_sync_syscall_soft_mirror(&p->task, sf);
 }
 
 void process_capture_syscall_frame(process_t *p)

--- a/kernel/process/core.c
+++ b/kernel/process/core.c
@@ -219,6 +219,10 @@ void process_sync_task_user_ip_from_syscall_frame(process_t *p)
 
 void process_capture_syscall_frame(process_t *p)
 {
+	/*
+	 * Capture is at syscall entry (arch_process_capture_syscall_frame_at_entry).
+	 * Dispatch still calls this; keep it as a documented no-op.
+	 */
 	(void)p;
 }
 
@@ -316,8 +320,10 @@ static void process_apply_kernel_ret_segments(process_t *p)
 }
 
 /*
- * process_arm_kernel_syscall_sleep - Linux-like: mark blocked syscall for
+ * process_arm_kernel_syscall_sleep - Prepare a blocked syscall for
  * kernel_ret resume after switch_context save (not via user RIP).
+ *
+ * Name: "arm" is the English verb (prepare/enable), not the ARM ISA.
  *
  * User regs live in syscall_frame (pt_regs). If task.arch.rip still looks like
  * userspace (stale from a prior iretq), only set want_kernel_ret — never pair

--- a/kernel/process/create.c
+++ b/kernel/process/create.c
@@ -14,19 +14,11 @@
 
 #include "process_internal.h"
 
-/* 
- * spawn() - Create a new process (IR0's ONLY process creation method)
- * 
- * IR0 PHILOSOPHY: Total simplicity with explicit mode specification
- * Only spawn() creates processes. No fork(), no clone(), no other methods.
- * Mode must be explicitly specified - no magic address detection.
- * 
- * This avoids fragile heuristics based on memory layout that could:
- * - Break if layout changes
- * - Allow user code to run in kernel mode
- * - Create hard-to-track bugs
- * 
- * process_fork() exists only for POSIX syscall compatibility and uses spawn() internally.
+/*
+ * spawn() creates a new process with an explicit mode (kernel vs user).
+ * POSIX fork()/clone() live in fork.c: they build the child with
+ * fork_process_create() and domain clones (mm, files, ...). They do not
+ * call spawn() internally.
  */
 int process_kernel_stack_alloc(process_t *p)
 {

--- a/sched/rr_sched.c
+++ b/sched/rr_sched.c
@@ -22,10 +22,19 @@
 #include <ir0/arch_port.h>
 #include <stdint.h>
 
-/* Scheduler state - circular queue of runnable processes */
-static rr_task_t *rr_head = NULL;   /* Head of circular queue (first to run) */
-static rr_task_t *rr_tail = NULL;   /* Tail of circular queue (last to run) */
-static rr_task_t *rr_current = NULL; /* Currently running process in queue */
+/*
+ * Ready list is singly linked (head -> ... -> tail, next=NULL). Advance wraps
+ * with `next ? next : rr_head`; it is not a circular queue.
+ */
+static rr_task_t *rr_head = NULL;
+static rr_task_t *rr_tail = NULL;
+static rr_task_t *rr_current = NULL;
+
+/*
+ * Bound a pick walk if the list is dirty with zombies/blocked tasks.
+ * Prevents livelock; not a statement about maximum process count.
+ */
+#define RR_MAX_PICK_ATTEMPTS 100
 
 /*
  * UP scheduler critical sections:
@@ -53,7 +62,7 @@ static inline void rr_irq_restore(uint64_t flags)
  * 1. Validate process pointer (prevent NULL pointer dereference)
  * 2. Allocate scheduler node (panic on failure - critical path)
  * 3. Link process to scheduler node
- * 4. Append to tail of circular queue (maintains order)
+ * 4. Append to tail of the ready list (maintains FIFO order)
  * 5. Mark process as READY (eligible for scheduling)
  *
  * Complexity: O(1) - constant time insertion
@@ -86,14 +95,14 @@ void rr_add_process(process_t *proc)
 	BUG_ON(!proc); /* Invalid process parameter - should never happen */
 	
 	/* Initialize scheduler node with process pointer.
-	 * The node will be linked into the circular queue.
+	 * The node will be linked into the ready list.
 	 */
 	node->process = proc;
 	node->next = NULL;
 
 	irq_flags = rr_irq_save();
 
-	/* Insert into circular queue.
+	/* Insert at tail of the singly-linked ready list.
 	 * If queue is empty, initialize head and tail to point to new node.
 	 * Otherwise, append to tail and update tail pointer.
 	 * This maintains FIFO order for fair scheduling.
@@ -139,7 +148,7 @@ void rr_add_process(process_t *proc)
  *
  * Algorithm:
  * 1. Find the scheduler node containing this process
- * 2. Remove node from circular queue (handle head, middle, tail cases)
+ * 2. Remove node from the ready list (handle head, middle, tail cases)
  * 3. Free scheduler node
  * 4. Update rr_current if it pointed to removed node
  *
@@ -218,7 +227,6 @@ void rr_schedule_next(void)
 	process_t *next = NULL;
 	uint64_t irq_flags = rr_irq_save();
 	int attempts = 0;
-	const int max_attempts = 100;
 
 	if (!rr_head)
 	{
@@ -231,7 +239,7 @@ void rr_schedule_next(void)
 	else
 		rr_current = rr_current->next ? rr_current->next : rr_head;
 
-	while (rr_current && attempts < max_attempts)
+	while (rr_current && attempts < RR_MAX_PICK_ATTEMPTS)
 	{
 		next = rr_current->process;
 

--- a/scripts/architecture_guard.py
+++ b/scripts/architecture_guard.py
@@ -68,6 +68,8 @@ REQUIRED_FACADES = [
     ROOT / "includes" / "ir0" / "arch_switch.h",
     ROOT / "includes" / "ir0" / "arch_mm.h",
     ROOT / "includes" / "ir0" / "arch_signal.h",
+    ROOT / "includes" / "ir0" / "arch_elf.h",
+    ROOT / "includes" / "ir0" / "arch_syscall_frame.h",
 ]
 
 REQUIRED_ARM64_SCAFFOLD = [
@@ -919,12 +921,13 @@ def check_process_pgd_accessor():
 
 # syscall_user_frame_t fields — portable code uses process_syscall_* accessors.
 SYSCALL_FRAME_FIELD_RE = re.compile(
-    r"syscall_frame\.(rip|rsp|rflags|rdi|rsi|rdx|r10|r8|r9|rbx|rbp|r12|r13|r14|r15)\b"
+    r"syscall_frame\.(rip|rsp|rflags|rdi|rsi|rdx|r10|r8|r9|rbx|rbp|r12|r13|r14|r15|"
+    r"elr|spsr|sp|x0|x1|x2|x3|x4|x5)\b"
 )
 
 SYSCALL_FRAME_ALLOWLIST = {
-    ROOT / "kernel" / "process.h",
-    ROOT / "kernel" / "process" / "core.c",
+    ROOT / "includes" / "ir0" / "arch_syscall_frame_x86_64.h",
+    ROOT / "includes" / "ir0" / "arch_syscall_frame_arm64.h",
 }
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The portability intent was already real (`task_t` + `arch_task_context_t`, `task_get_ip/sp/retval`, `arch_fork_prepare_*`, real x86 vs ARM switch backends, `architecture_guard.py`). Effective userspace was still x86-centric.

This round closes the leaks that were actually wired, without rewriting `process_t` or the x86 `arch_switch_to()` resume maze.

## Syscall frame

`arch_syscall_frame_t` no longer lives in `kernel/process.h` as an x86 `rip/rdi/r10` struct.

- `includes/ir0/arch_syscall_frame_x86_64.h` — Linux x86-64 syscall ABI
- `includes/ir0/arch_syscall_frame_arm64.h` — AAPCS64: args `x0..x5`, IP `elr`, SP `sp`, flags `spsr`
- `process_syscall_ip/sp/arg` are thin wrappers over those accessors
- `arch_task_syscall_frame_t` is the same type (the duplicated x86 `pt_regs` copy is gone)
- ARM capture fills the frame from `vectors.S` `exc_entry_frame` and fork applies it like x86
- `signals.c` fills `sigcontext` through `arch_signal_fill_sigcontext_from_syscall_frame()` instead of naming `rdi`/`rip`

## ELF

`kernel/elf_loader.c` no longer requires `EM_X86_64`. It uses `arch_elf_machine_supported()` (`EM_X86_64` or `EM_AARCH64` per build). Early ARM loaders go through the same facade. Entry argc/argv/envp uses `task_set_arg0/1/2`.

## ARM TLS

`arch_process_set_tls()` programs `process_tls_*` and `TPIDR_EL0` instead of returning `-EOPNOTSUPP`. `arch_switch_to()` restores the incoming task’s TLS. `set_tls()` is the portable name; `set_fs_base()` is the ISA install (FS base / `TPIDR_EL0`).

## Scars (comments / small structure)

- `includes/ir0/process.h` no longer pretends to be a sealed facade; `process_t` is still a large aggregate with mm/files extracted
- `create.c` / `process.h` no longer claim fork uses `spawn()` internally
- `process_arm_*` is documented as the English verb “arm a resume path”, not ARM64
- RR comments match the structure: singly-linked ready list with head wrap, `RR_MAX_PICK_ATTEMPTS` (100)
- x86 `arch_switch_to()` is **not** retangled — only a regression warning on wait4 / `irq_frame_saved` / syscall-resume / kernel-ret vs user-iret

`architecture_guard.py` requires `arch_elf.h` and `arch_syscall_frame.h`, and the syscall-frame field check covers ARM names too.

Still not a 10/10: `process_t` layout is public, ARM userspace is not at x86 product parity, and the x86 switch resume path remains the high-regression area.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-33f90915-231f-4526-a224-37d78303db46?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-33f90915-231f-4526-a224-37d78303db46&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

